### PR TITLE
Automated build & release actions for individual providers

### DIFF
--- a/.github/workflows/fs-release.yml
+++ b/.github/workflows/fs-release.yml
@@ -1,0 +1,87 @@
+name: FS-RELEASE
+
+on:
+  push:
+    tags:
+    - 'fs-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./fs
+  DESTINATION: fs.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_FS }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/fs:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/fs:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/fs.yml
+++ b/.github/workflows/fs.yml
@@ -1,0 +1,39 @@
+name: FS
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "fs/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "fs/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./fs
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/httpclient-release.yml
+++ b/.github/workflows/httpclient-release.yml
@@ -1,0 +1,87 @@
+name: HTTPCLIENT-RELEASE
+
+on:
+  push:
+    tags:
+    - 'httpclient-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./httpclient
+  DESTINATION: httpclient.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_HTTPCLIENT }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/httpclient:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/httpclient:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -1,0 +1,39 @@
+name: HTTPCLIENT
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "http-client/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "http-client/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./http-client
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/httpserver-release.yml
+++ b/.github/workflows/httpserver-release.yml
@@ -1,0 +1,87 @@
+name: HTTPSERVER-RELEASE
+
+on:
+  push:
+    tags:
+    - 'httpserver-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./httpserver
+  DESTINATION: httpserver.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_HTTPSERVER }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/httpserver:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/httpserver:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -1,0 +1,39 @@
+name: HTTPSERVER
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "http-server/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "http-server/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./http-server
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/logging-release.yml
+++ b/.github/workflows/logging-release.yml
@@ -1,0 +1,87 @@
+name: LOGGING-RELEASE
+
+on:
+  push:
+    tags:
+    - 'logging-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./logging
+  DESTINATION: logging.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_LOGGING }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/logging:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/logging:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/logging.yml
+++ b/.github/workflows/logging.yml
@@ -1,0 +1,39 @@
+name: LOGGING
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "logging/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "logging/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./logging
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/redis-release.yml
+++ b/.github/workflows/redis-release.yml
@@ -1,0 +1,87 @@
+name: REDIS-RELEASE
+
+on:
+  push:
+    tags:
+    - 'redis-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./redis
+  DESTINATION: redis.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_REDIS }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/redis:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/redis:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redis.yml
+++ b/.github/workflows/redis.yml
@@ -1,0 +1,39 @@
+name: REDIS
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "redis/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "redis/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./redis
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/redisgraph-release.yml
+++ b/.github/workflows/redisgraph-release.yml
@@ -1,0 +1,87 @@
+name: REDISGRAPH-RELEASE
+
+on:
+  push:
+    tags:
+    - 'redisgraph-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./redisgraph
+  DESTINATION: redisgraph.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_REDISGRAPH }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/redisgraph:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/redisgraph:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redisgraph.yml
+++ b/.github/workflows/redisgraph.yml
@@ -1,0 +1,39 @@
+name: REDISGRAPH
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "redisgraph/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "redisgraph/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./redisgraph
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/redisstreams-release.yml
+++ b/.github/workflows/redisstreams-release.yml
@@ -1,0 +1,87 @@
+name: REDISSTREAMS-RELEASE
+
+on:
+  push:
+    tags:
+    - 'redisstreams-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./redisstreams
+  DESTINATION: redisstreams.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_REDISSTREAMS }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/redisstreams:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/redisstreams:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redisstreams.yml
+++ b/.github/workflows/redisstreams.yml
@@ -1,0 +1,39 @@
+name: REDISSTREAMS
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "redis-streams/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "redis-streams/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./redis-streams
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/s3-release.yml
+++ b/.github/workflows/s3-release.yml
@@ -1,0 +1,87 @@
+name: S3-RELEASE
+
+on:
+  push:
+    tags:
+    - 's3-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./s3
+  DESTINATION: s3.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_S3 }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/s3:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/s3:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/s3.yml
+++ b/.github/workflows/s3.yml
@@ -1,0 +1,39 @@
+name: S3
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "s3/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "s3/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./s3
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}

--- a/.github/workflows/telnet-release.yml
+++ b/.github/workflows/telnet-release.yml
@@ -1,0 +1,87 @@
+name: TELNET-RELEASE
+
+on:
+  push:
+    tags:
+    - 'telnet-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./telnet
+  DESTINATION: telnet.par.gz #aka the filename of the parJEEzy
+  WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
+  WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_TELNET }}
+  WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
+  WASH_REG_PASSWORD:  ${{ secrets.AZURECR_PUSH_PASSWORD }}
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+
+  artifact_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | sudo bash
+          sudo apt install wash
+      - run: cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target --force # Installing from feature branch until PR merged
+      - name: build-par
+        run: make par
+        working-directory: ${{ env.working-directory }}
+      # Push artifact to https://AZURECR/telnet:VERSION
+      - name: push-par
+        run: |
+          VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
+          URL=${{secrets.AZURECR_PUSH_URL}}/telnet:$VERSION
+          wash reg push $URL ${{ env.DESTINATION }}
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/telnet.yml
+++ b/.github/workflows/telnet.yml
@@ -1,0 +1,39 @@
+name: TELNET
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "telnet/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "telnet/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./telnet
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}


### PR DESCRIPTION
Fixes #16

All of these additions here are copy/pasted from the TEMPLATEs in the `.github/workflows` directory, so it's all the same code coming in. Each individual build action (the `provider.yml`s) build and test the provider when a file has been modified in that specific provider. This saves a _lot_ of time, especially when we are working on capability providers individually. The release action (`provider-release.yml`) will build, test, and release the provider to `crates.io` and a parJEEzy to our wasmcloud azure registry for distribution. This action is kicked off by pushing a tag to the main branch with the form of `provider-vX.Y.Z`, for example `redisgraph-v0.9.2`. After merging this PR, I will tag an initial release for each provider.