### PR TITLE
Update S3 to 0.15 compliance and blobstore actor interface

### DIFF
--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "wascc-s3"
-version = "0.7.1"
-authors = ["Kevin Hoffman <alothien@gmail.com>"]
+name = "wasmcloud-s3"
+version = "0.8.0"
+authors = ["wasmCloud Team"]
 edition = "2018"
-homepage = "https://wascc.dev"
-repository = "https://github.com/wascc/s3-provider"
-description = "AWS S3 capability provider for the waSCC wasm host runtime"
+homepage = "https://wasmcloud.dev"
+repository = "https://github.com/wasmcloud/capability-providers"
+description = "AWS S3 capability provider for the wasmCloud wasm host runtime"
 license = "Apache-2.0"
-documentation = "https://docs.rs/wascc-s3"
+documentation = "https://docs.rs/wasmcloud-s3"
 readme = "README.md"
-keywords = ["webassembly", "wasm", "aws", "wascc", "s3"]
+keywords = ["webassembly", "wasm", "aws", "wasmcloud", "s3"]
 categories = ["wasm", "api-bindings"]
 
 [badges]
@@ -23,7 +23,7 @@ static_plugin = []
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wascc-codec = "0.8.1"
+wascc-codec = "0.9.0"
 log = "0.4.11"
 env_logger = "0.7.1"
 rusoto_core = { version="0.45.0", default_features=false, features=["rustls"] }
@@ -32,6 +32,8 @@ rusoto_credential = "0.45.0"
 tokio = { version = "0.2.22", features = ["macros", "rt-threaded"]}
 futures = "0.3"
 bytes = "0.5"
+actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
+actor-blobstore = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
 
 [dev-dependencies]
 crossbeam = "0.7.3"

--- a/s3/src/s3.rs
+++ b/s3/src/s3.rs
@@ -1,5 +1,5 @@
 use crate::FileUpload;
-use codec::core::CapabilityConfiguration;
+use actor_core::CapabilityConfiguration;
 use futures::TryStreamExt;
 use rusoto_core::credential::{DefaultCredentialsProvider, StaticProvider};
 use rusoto_core::Region;


### PR DESCRIPTION
Related to #12 

This updates the S3 provider to 0.15 compliance and using the `wasmcloud:blobstore` contract ID and actor interface.

I've confirmed that the previous test suite runs & passes, I've also included a `docker run` oneliner for future tests of this project because it took me a few minutes to track down the exact Minio server flags that I needed.