### PR TITLE
Http client 0.15

### DIFF
--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasmcloud-httpclient"
 version = "0.2.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
-repository = "https://github.com/wasmcloud/http-client-provider"
+repository = "https://github.com/wasmcloud/capability-providers"
 description = "HTTP client capability provider for the wasmCloud wasm host runtime"
 license = "Apache-2.0"
 documentation = "https://docs.rs/wasmcloud-httpclient"
@@ -28,8 +28,8 @@ reqwest = { version = "0.11", features = ["json", "gzip", "brotli"] }
 tokio = { version = "1.1.1", features = ["rt-multi-thread", "net", "time", "macros", "signal"] }
 base64 = "0.13.0"
 serde_json = "1.0.61"
-actor-http-client = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main"}
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main"}
+wasmcloud-actor-http-client = "0.1.0"
+wasmcloud-actor-core = "0.2.0"
 
 [dev-dependencies]
 mockito = "0.29"

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
-name = "wascc-httpclient"
-version = "0.1.0"
-authors = ["Dan Norris <protochron@users.noreply.github.com>"]
+name = "wasmcloud-httpclient"
+version = "0.2.0"
+authors = ["wasmCloud Team"]
 edition = "2018"
-repository = "https://github.com/wascc/http-client-provider"
-description = "HTTP client capability provider for the waSCC wasm host runtime"
+repository = "https://github.com/wasmcloud/http-client-provider"
+description = "HTTP client capability provider for the wasmCloud wasm host runtime"
 license = "Apache-2.0"
-documentation = "https://docs.rs/wascc-host"
+documentation = "https://docs.rs/wasmcloud-httpclient"
 readme = "README.md"
-keywords = ["webassembly", "wasm", "wasi", "wascc"]
+keywords = ["webassembly", "wasm", "wasi", "wasmcloud", "http"]
 categories = ["wasm", "api-bindings"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -20,15 +20,17 @@ static_plugin = []
 crate-type = ["cdylib", "rlib"]
 
 [dependencies]
-wascc-codec = "0.7.0"
-log = "0.4.8"
-futures = "0.3.5"
-env_logger = "0.7.1"
-reqwest = { version = "0.10", features = ["json", "gzip", "brotli"] }
-tokio = { version = "0.2", features = ["rt-threaded", "tcp", "time", "macros", "signal", "dns"] }
-base64 = "0.12.1"
-serde_json = "1.0.53"
+wascc-codec = "0.9.0"
+log = "0.4.14"
+futures = "0.3.12"
+env_logger = "0.8.2"
+reqwest = { version = "0.11", features = ["json", "gzip", "brotli"] }
+tokio = { version = "1.1.1", features = ["rt-multi-thread", "net", "time", "macros", "signal"] }
+base64 = "0.13.0"
+serde_json = "1.0.61"
+actor-http-client = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main"}
+actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main"}
 
 [dev-dependencies]
-mockito = "0.25"
-tokio = { version = "0.2", features = ["rt-threaded", "tcp", "time", "macros", "signal", "dns", "full"]}
+mockito = "0.29"
+tokio = { version = "1.1.1", features = ["rt-multi-thread", "net", "time", "macros", "signal", "full"]}

--- a/http-client/README.md
+++ b/http-client/README.md
@@ -1,4 +1,2 @@
-![Rust](https://github.com/wascc/http-client-provider/workflows/Rust/badge.svg)
-
 # HTTP Client Provider
-The HTTP Client provider allows waSCC actors to make outbound HTTP requests
+The HTTP Client provider allows wasmCloud actors to make outbound HTTP requests

--- a/http-client/src/http_client.rs
+++ b/http-client/src/http_client.rs
@@ -52,16 +52,10 @@ fn build_request(
     req: RequestArgs,
 ) -> Result<RequestBuilder, Box<dyn std::error::Error + Send + Sync>> {
     let mut r = match req.method.as_str() {
-        "GET" => {
-            let r = client.get(&req.url);
-            Ok(r)
-        }
-        "POST" => {
-            let r = client.post(&req.url).body(req.body);
-            Ok(r)
-        }
+        "GET" => Ok(client.get(&req.url)),
+        "POST" => Ok(client.post(&req.url).body(req.body)),
         "HEAD" => Ok(client.head(&req.url)),
-        "PUT" => Ok(client.put(&req.url)),
+        "PUT" => Ok(client.put(&req.url).body(req.body)),
         "DELETE" => Ok(client.delete(&req.url)),
         "PATCH" => Ok(client.patch(&req.url)),
         "OPTIONS" => Ok(client.request(reqwest::Method::OPTIONS, &req.url)),

--- a/http-client/src/lib.rs
+++ b/http-client/src/lib.rs
@@ -152,9 +152,7 @@ impl CapabilityProvider for HttpClientProvider {
         }
     }
 
-    fn stop(&self) {
-        todo!()
-    }
+    fn stop(&self) {}
 }
 
 #[cfg(test)]

--- a/http-client/src/lib.rs
+++ b/http-client/src/lib.rs
@@ -1,6 +1,5 @@
-///!
-///! # http-client-provider
-///! This library exposes the HTTP client capability to waSCC-compliant actors
+///! http-client-provider
+///! This library exposes the HTTP client capability to wasmCloud-compliant actors
 mod http_client;
 
 #[macro_use]
@@ -9,30 +8,30 @@ extern crate wascc_codec as codec;
 #[macro_use]
 extern crate log;
 
-use codec::capabilities::{
-    CapabilityDescriptor, CapabilityProvider, Dispatcher, NullDispatcher, OperationDirection,
-    OP_GET_CAPABILITY_DESCRIPTOR,
-};
-use codec::core::{CapabilityConfiguration, OP_BIND_ACTOR, OP_REMOVE_ACTOR};
-use codec::http::{Request, OP_PERFORM_REQUEST};
-use codec::{deserialize, serialize, SYSTEM_ACTOR};
+extern crate actor_http_client as http;
+use actor_core::CapabilityConfiguration;
+use codec::capabilities::{CapabilityProvider, Dispatcher, NullDispatcher};
+use codec::core::{OP_BIND_ACTOR, OP_REMOVE_ACTOR};
+use codec::{deserialize, SYSTEM_ACTOR};
+use http::{Request, OP_PERFORM_REQUEST};
 use std::collections::HashMap;
 use std::error::Error;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
-const CAPABILITY_ID: &str = "wascc:http_client";
+const CAPABILITY_ID: &str = "wasmcloud:httpclient";
 const VERSION: &str = env!("CARGO_PKG_VERSION");
-const REVISION: u32 = 0;
+const REVISION: u32 = 1;
 
 #[cfg(not(feature = "static_plugin"))]
 capability_provider!(HttpClientProvider, HttpClientProvider::new);
 
 /// An implementation HTTP client provider using reqwest.
+#[derive(Clone)]
 pub struct HttpClientProvider {
     dispatcher: Arc<RwLock<Box<dyn Dispatcher>>>,
     clients: Arc<RwLock<HashMap<String, reqwest::Client>>>,
-    runtime: tokio::runtime::Runtime,
+    runtime: Arc<tokio::runtime::Runtime>,
 }
 
 impl HttpClientProvider {
@@ -44,7 +43,10 @@ impl HttpClientProvider {
     /// Configure the HTTP client for a particular actor.
     /// Each actor gets a dedicated client so that we can take advantage of connection pooling.
     /// TODO: This needs to set things like timeouts, redirects, etc.
-    fn configure(&self, config: CapabilityConfiguration) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn configure(
+        &self,
+        config: CapabilityConfiguration,
+    ) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
         let timeout = match config.values.get("timeout") {
             Some(v) => {
                 let parsed: u64 = v.parse()?;
@@ -73,7 +75,10 @@ impl HttpClientProvider {
 
     /// Clean up resources when a actor disconnects.
     /// This removes the HTTP client associated with an actor.
-    fn deconfigure(&self, config: CapabilityConfiguration) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn deconfigure(
+        &self,
+        config: CapabilityConfiguration,
+    ) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
         if self
             .clients
             .write()
@@ -91,26 +96,11 @@ impl HttpClientProvider {
     }
 
     /// Make a HTTP request.
-    fn request(&self, actor: &str, msg: Request) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn request(&self, actor: &str, msg: Request) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
         let lock = self.clients.read().unwrap();
         let client = lock.get(actor).unwrap();
         self.runtime
-            .handle()
             .block_on(async { http_client::request(&client, msg).await })
-    }
-
-    fn get_descriptor(&self) -> Result<Vec<u8>, Box<dyn Error>> {
-        use OperationDirection::ToProvider;
-        Ok(serialize(
-            CapabilityDescriptor::builder()
-                .id(CAPABILITY_ID)
-                .name("wasCC HTTP Client Provider")
-                .long_description("A http client provider")
-                .version(VERSION)
-                .revision(REVISION)
-                .with_operation(OP_PERFORM_REQUEST, ToProvider, "Perform a http request")
-                .build(),
-        )?)
     }
 }
 
@@ -118,8 +108,7 @@ impl Default for HttpClientProvider {
     fn default() -> Self {
         let _ = env_logger::builder().format_module_path(false).try_init();
 
-        let r = tokio::runtime::Builder::new()
-            .threaded_scheduler()
+        let r = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
             .build()
             .unwrap();
@@ -127,14 +116,17 @@ impl Default for HttpClientProvider {
         HttpClientProvider {
             dispatcher: Arc::new(RwLock::new(Box::new(NullDispatcher::new()))),
             clients: Arc::new(RwLock::new(HashMap::new())),
-            runtime: r,
+            runtime: Arc::new(r),
         }
     }
 }
 
 /// Implements the CapabilityProvider interface.
 impl CapabilityProvider for HttpClientProvider {
-    fn configure_dispatch(&self, dispatcher: Box<dyn Dispatcher>) -> Result<(), Box<dyn Error>> {
+    fn configure_dispatch(
+        &self,
+        dispatcher: Box<dyn Dispatcher>,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
         info!("Dispatcher configured");
 
         let mut lock = self.dispatcher.write().unwrap();
@@ -143,22 +135,30 @@ impl CapabilityProvider for HttpClientProvider {
     }
 
     /// Handle all calls from actors.
-    fn handle_call(&self, actor: &str, op: &str, msg: &[u8]) -> Result<Vec<u8>, Box<dyn Error>> {
+    fn handle_call(
+        &self,
+        actor: &str,
+        op: &str,
+        msg: &[u8],
+    ) -> Result<Vec<u8>, Box<dyn Error + Send + Sync>> {
         match op {
             OP_BIND_ACTOR if actor == SYSTEM_ACTOR => self.configure(deserialize(msg)?),
             OP_REMOVE_ACTOR if actor == SYSTEM_ACTOR => self.deconfigure(deserialize(msg)?),
             OP_PERFORM_REQUEST => self.request(actor, deserialize(msg)?),
-            OP_GET_CAPABILITY_DESCRIPTOR => self.get_descriptor(),
             _ => Err(format!("Unknown operation: {}", op).into()),
         }
+    }
+
+    fn stop(&self) {
+        todo!()
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use actor_http_client::{Request, Response};
     use codec::deserialize;
-    use codec::http::Response;
     use mockito::mock;
 
     #[test]
@@ -166,7 +166,8 @@ mod tests {
         let _ = env_logger::try_init();
         let request = Request {
             method: "GET".to_string(),
-            path: mockito::server_url(),
+            url: mockito::server_url(),
+            path: "/".to_string(),
             header: HashMap::new(),
             body: vec![],
             query_string: String::new(),


### PR DESCRIPTION
- Updated to use http-client actor interface (will fail CI/CD since the interface isn't published yet)
- Updated tests accordingly
- Updated dependencies, namely Tokio `0.2` -> `1.1.1`
