### PR TITLE
Updated logging provider to 0.15 compliance and interface versions

### DIFF
--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
-name = "wascc-logging"
-version = "0.8.0"
-authors = ["Kevin Hoffman <alothien@gmail.com>"]
+name = "wasmcloud-logging"
+version = "0.9.0"
+authors = ["wasmCloud Team"]
 edition = "2018"
-homepage = "https://wascc.dev"
-repository = "https://github.com/wascc/logging-provider"
-description = "Structured logging capability provider for the waSCC host runtime"
+homepage = "https://wasmcloud.dev"
+repository = "https://github.com/wasmcloud/capability-providers"
+description = "Structured logging capability provider for the wasmCloud host runtime"
 license = "Apache-2.0"
-documentation = "https://docs.rs/wascc-logging"
+documentation = "https://docs.rs/wasmcloud-logging"
 readme = "README.md"
-keywords = ["webassembly", "wasm", "wasi", "wascc", "logging"]
+keywords = ["webassembly", "wasm", "wasi", "wasmcloud", "logging"]
 categories = ["wasm", "api-bindings"]
 
 [badges]
@@ -22,6 +22,8 @@ crate-type = ["cdylib", "rlib"]
 static_plugin = [] # Enable to statically compile this into a host
 
 [dependencies]
-wascc-codec = "0.8.0"
-log = "0.4.8"
-env_logger = "0.7.1"
+wascc-codec = "0.9.0"
+log = "0.4.14"
+env_logger = "0.8.2"
+wasmcloud-actor-core = "0.2.0"
+wasmcloud-actor-logging = "0.1.0"

--- a/logging/README.md
+++ b/logging/README.md
@@ -1,17 +1,16 @@
-[![crates.io](https://img.shields.io/crates/v/wascc-logging.svg)](https://crates.io/crates/wascc-logging)&nbsp;
-![Rust](https://github.com/wascc/logging-provider/workflows/Rust/badge.svg)&nbsp;
-![license](https://img.shields.io/crates/l/wascc-logging.svg)&nbsp;
-[![documentation](https://docs.rs/wascc-logging/badge.svg)](https://docs.rs/wascc-logging)
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-logging.svg)](https://crates.io/crates/wasmcloud-logging)&nbsp;
+![Rust](https://github.com/wasmcloud/logging-provider/workflows/Rust/badge.svg)&nbsp;
+![license](https://img.shields.io/crates/l/wasmcloud-logging.svg)&nbsp;
+[![documentation](https://docs.rs/wasmcloud-logging/badge.svg)](https://docs.rs/wasmcloud-logging)
 
-# waSCC Logging Provider
+# wasmCloud Logging Provider
 
-This library is a _native capability provider_ for the `wascc:logging` capability. Only actors signed with tokens containing this capability privilege will be allowed to use it.  It allows actors to use normal `log` macros (like `info!`, `warn!`, `error!`, etc, to write logs from within the actor.
+This library is a _native capability provider_ for the `wasmcloud:logging` capability. Only actors signed with tokens containing this capability privilege will be allowed to use it. It allows actors to use normal `log` macros (like `info!`, `warn!`, `error!`, etc, to write logs from within the actor.
 
-It should be compiled as a native linux (`.so`) binary and made available to the **waSCC** host runtime as a plugin. 
+It should be compiled as a native binary (linux: `.so`, mac: `.dylib`, windows: `dll`, etc) and made available to the **wasmCloud** host runtime as a plugin. This is commonly done by creating a [provider-archive](https://github.com/wasmCloud/provider-archive)
 
 If you want to statically link (embed) this capability provider into a custom host, then enable the `static_plugin` feature in your dependencies as follows:
 
 ```
-wascc-logging = { version="??", features = ["static_plugin"] }
+wasmcloud-logging = { version="??", features = ["static_plugin"] }
 ```
-


### PR DESCRIPTION
PR incoming with all other providers updated to use interface versions.

This logging provider has been tested and verified to log messages that are logged in an actor, both using `write_log` directly and using log macros (e.g. `error!`, `info!`).