### PR TITLE
Updating 0.15 providers to actor interface pinned versions

### DIFF
--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-fs"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -23,5 +23,5 @@ static_plugin = []
 wascc-codec = "0.9.0"
 log = "0.4.11"
 env_logger = "0.7.1"
-actor-blobstore = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
+wasmcloud-actor-blobstore = "0.1.0"
+wasmcloud-actor-core = "0.2.0"

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -4,8 +4,6 @@ extern crate wascc_codec as codec;
 #[macro_use]
 extern crate log;
 
-use actor_blobstore::*;
-use actor_core::CapabilityConfiguration;
 use chunks::Chunks;
 use codec::capabilities::{CapabilityProvider, Dispatcher, NullDispatcher};
 use codec::core::{OP_BIND_ACTOR, OP_REMOVE_ACTOR};
@@ -18,6 +16,8 @@ use std::{
     path::{Path, PathBuf},
     sync::{Arc, RwLock},
 };
+use wasmcloud_actor_blobstore::*;
+use wasmcloud_actor_core::CapabilityConfiguration;
 
 mod chunks;
 
@@ -358,13 +358,13 @@ impl CapabilityProvider for FileSystemProvider {
 mod tests {
     use super::{sanitize_blob, sanitize_container};
     use crate::FileSystemProvider;
-    use actor_blobstore::{Blob, Container, FileChunk};
-    use actor_core::CapabilityConfiguration;
     use std::collections::HashMap;
     use std::env::temp_dir;
     use std::fs::File;
     use std::io::{BufReader, Read};
     use std::path::{Path, PathBuf};
+    use wasmcloud_actor_blobstore::{Blob, Container, FileChunk};
+    use wasmcloud_actor_core::CapabilityConfiguration;
 
     #[test]
     fn no_hacky_hacky() {

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-httpserver"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -9,7 +9,7 @@ description = "HTTP Server capability provider for the wasmCloud host runtime"
 license = "Apache-2.0"
 documentation = "https://docs.rs/wasmcloud-httpserver"
 readme = "README.md"
-keywords = ["webassembly", "wasm", "wasi", "wascc", "actix"]
+keywords = ["webassembly", "wasm", "wasi", "wasmcloud", "actix"]
 categories = ["wasm", "api-bindings"]
 
 [badges]
@@ -35,5 +35,5 @@ env_logger = "0.7.1"
 crossbeam-channel = "0.4.2"
 crossbeam = "0.7.3"
 crossbeam-utils = "^0.7.0"
-actor-http-server = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
+wasmcloud-actor-http-server = "0.1.0"
+wasmcloud-actor-core = "0.2.0"

--- a/nats-kvcache/Cargo.toml
+++ b/nats-kvcache/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "nats-kvcache"
-version = "0.1.0"
+version = "0.3.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 license-file = "LICENSE.txt"
 description = "A key-value capability provider for wasmCloud that replicates data changes over NATS"
-repository = "https://github.com/wascc/wasccd"
+repository = "https://github.com/wasmcloud/capability-providers"
 documentation = "https://wasmcloud.com"
 readme = "README.md"
 keywords = [
@@ -28,8 +28,8 @@ crate-type = ["cdylib", "rlib"]
 static_plugin = []
 
 [dependencies]
-actor-keyvalue = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main"}
-actor-core = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main"}
+wasmcloud-actor-keyvalue = "0.2.0"
+wasmcloud-actor-core = "0.2.0"
 nats = "0.8.6"
 wascc-codec = "0.9.0"
 wascap = "0.5.1"

--- a/nats-kvcache/src/lib.rs
+++ b/nats-kvcache/src/lib.rs
@@ -30,8 +30,8 @@ extern crate eventsourcing_derive;
 
 extern crate eventsourcing;
 
-extern crate actor_core as core;
-extern crate actor_keyvalue as keyvalue;
+extern crate wasmcloud_actor_core as core;
+extern crate wasmcloud_actor_keyvalue as keyvalue;
 #[macro_use]
 extern crate wascc_codec as codec;
 #[macro_use]

--- a/nats-kvcache/tests/integration.rs
+++ b/nats-kvcache/tests/integration.rs
@@ -2,13 +2,13 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use actor_core::{deserialize, serialize, CapabilityConfiguration};
-use actor_keyvalue::{
+use nats_kvcache::NatsReplicatedKVProvider;
+use wascc_codec::{capabilities::CapabilityProvider, core::OP_BIND_ACTOR};
+use wasmcloud_actor_core::{deserialize, serialize, CapabilityConfiguration};
+use wasmcloud_actor_keyvalue::{
     AddArgs, GetArgs, GetResponse, SetAddArgs, SetQueryArgs, SetQueryResponse, OP_ADD, OP_GET,
     OP_SET_ADD, OP_SET_QUERY,
 };
-use nats_kvcache::NatsReplicatedKVProvider;
-use wascc_codec::{capabilities::CapabilityProvider, core::OP_BIND_ACTOR};
 
 #[test]
 fn steadystate_and_replay() {

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-redis"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -33,5 +33,5 @@ crossbeam-utils = "0.8.1"
 log = "0.4.11"
 wascc-codec = "0.9.0"
 redis = "0.17.0"
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
-actor-keyvalue = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
+wasmcloud-actor-core = "0.2.0"
+wasmcloud-actor-keyvalue = "0.2.0"

--- a/redis/src/kvredis.rs
+++ b/redis/src/kvredis.rs
@@ -1,5 +1,5 @@
-use wasmcloud_actor_core::CapabilityConfiguration;
 use std::error::Error;
+use wasmcloud_actor_core::CapabilityConfiguration;
 
 const ENV_REDIS_URL: &str = "URL";
 

--- a/redis/src/kvredis.rs
+++ b/redis/src/kvredis.rs
@@ -1,4 +1,4 @@
-use actor_core::CapabilityConfiguration;
+use wasmcloud_actor_core::CapabilityConfiguration;
 use std::error::Error;
 
 const ENV_REDIS_URL: &str = "URL";

--- a/redis/src/lib.rs
+++ b/redis/src/lib.rs
@@ -8,9 +8,9 @@ use codec::core::{OP_BIND_ACTOR, OP_HEALTH_REQUEST, OP_REMOVE_ACTOR};
 #[macro_use]
 extern crate log;
 
-extern crate actor_core as actorcore;
+extern crate wasmcloud_actor_core as actorcore;
 use actorcore::{deserialize, serialize, CapabilityConfiguration, HealthCheckResponse};
-extern crate actor_keyvalue as actorkeyvalue;
+extern crate wasmcloud_actor_keyvalue as actorkeyvalue;
 use actorkeyvalue::*;
 
 use redis::Connection;
@@ -21,10 +21,9 @@ use std::error::Error;
 use std::sync::Arc;
 use std::sync::RwLock;
 
+#[allow(unused)]
 const CAPABILITY_ID: &str = "wasmcloud:keyvalue";
 const SYSTEM_ACTOR: &str = "system";
-const REVISION: u32 = 3; // Increment for each crates publish
-const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 #[cfg(not(feature = "static_plugin"))]
 capability_provider!(RedisKVProvider, RedisKVProvider::new);

--- a/redisgraph/Cargo.toml
+++ b/redisgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-redisgraph"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -20,8 +20,8 @@ crate-type = ["cdylib", "rlib"]
 static_plugin = []
 
 [dependencies]
-actor-graphdb = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main"}
-actor-core = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main"}
+wasmcloud-actor-graphdb = "0.1.0"
+wasmcloud-actor-core = "0.2.0"
 wascc-codec = "0.9.0"
 log = "0.4.13"
 env_logger = "0.8.2"

--- a/redisgraph/examples/sample-graph-actor/Cargo.toml
+++ b/redisgraph/examples/sample-graph-actor/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "graph-actor"
-version = "0.0.1"
+version = "0.1.0"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 
@@ -9,10 +9,9 @@ crate-type = ["cdylib"]
 
 [dependencies]
 wapc-guest = "0.4.0"
-actor-graphdb = { path = "../../../../actor-interfaces/rust/graphdb", features = ["guest"] }
-actor-http-server = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main" }
-#actor-graphdb = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "graphdb", features = ["guest"]}
-actor-core = { git = "https://github.com/wasmCloud/actor-interfaces", branch = "main", features = ["guest"]}
+wasmcloud-actor-graphdb = { version = "0.1.1", features = ["guest"] }
+wasmcloud-actor-http-server = { version = "0.1.0", features = ["guest"]}
+wasmcloud-actor-core = { version = "0.2.0", features = ["guest"]}
 serde_json = "1.0.53"
 log = "0.4.8"
 

--- a/redisgraph/examples/sample-graph-actor/src/lib.rs
+++ b/redisgraph/examples/sample-graph-actor/src/lib.rs
@@ -22,9 +22,9 @@
 // **
 
 extern crate wapc_guest as guest;
-use actor_graphdb as graph;
-use actor_http_server as http;
 use guest::prelude::*;
+use wasmcloud_actor_graphdb as graph;
+use wasmcloud_actor_http_server as http;
 
 #[macro_use]
 extern crate serde_json;
@@ -35,7 +35,7 @@ extern crate log;
 #[no_mangle]
 pub fn wapc_init() {
     http::Handlers::register_handle_request(handle_http_request);
-    actor_core::Handlers::register_health_request(health);
+    wasmcloud_actor_core::Handlers::register_health_request(health);
 }
 
 fn handle_http_request(req: http::Request) -> HandlerResult<http::Response> {
@@ -73,6 +73,8 @@ fn query_data() -> HandlerResult<http::Response> {
     Ok(http::Response::json(result, 200, "OK"))
 }
 
-fn health(_req: actor_core::HealthCheckRequest) -> HandlerResult<actor_core::HealthCheckResponse> {
-    Ok(actor_core::HealthCheckResponse::healthy())
+fn health(
+    _req: wasmcloud_actor_core::HealthCheckRequest,
+) -> HandlerResult<wasmcloud_actor_core::HealthCheckResponse> {
+    Ok(wasmcloud_actor_core::HealthCheckResponse::healthy())
 }

--- a/redisgraph/src/conversions.rs
+++ b/redisgraph/src/conversions.rs
@@ -1,13 +1,13 @@
-use actor_graphdb;
-use actor_graphdb::generated::Column;
 use redisgraph;
 use redisgraph::result_set::Column::*;
 use redisgraph::result_set::Scalar;
 use std::collections::HashMap;
+use wasmcloud_actor_graphdb;
+use wasmcloud_actor_graphdb::generated::Column;
 
 pub(crate) fn redisgraph_column_to_common(
     rc: redisgraph::result_set::Column,
-) -> actor_graphdb::generated::Column {
+) -> wasmcloud_actor_graphdb::generated::Column {
     match rc {
         Scalars(s) => {
             let scalars = Some(
@@ -48,8 +48,8 @@ pub(crate) fn redisgraph_column_to_common(
 
 pub(crate) fn redisgraph_scalar_to_common(
     rs: redisgraph::result_set::Scalar,
-) -> actor_graphdb::generated::Scalar {
-    let mut scalar = actor_graphdb::generated::Scalar::default();
+) -> wasmcloud_actor_graphdb::generated::Scalar {
+    let mut scalar = wasmcloud_actor_graphdb::generated::Scalar::default();
     match rs {
         Scalar::Boolean(b) => scalar.bool_value = Some(b),
         Scalar::Double(d) => scalar.double_value = Some(d),
@@ -62,7 +62,7 @@ pub(crate) fn redisgraph_scalar_to_common(
 
 pub(crate) fn redisgraph_node_to_common(
     rn: redisgraph::result_set::Node,
-) -> actor_graphdb::generated::Node {
+) -> wasmcloud_actor_graphdb::generated::Node {
     let labels = rn
         .labels
         .into_iter()
@@ -73,19 +73,19 @@ pub(crate) fn redisgraph_node_to_common(
         .into_iter()
         .map(|(k, v)| (redisstring_to_string(k), redisgraph_scalar_to_common(v)))
         .collect::<HashMap<_, _>>();
-    actor_graphdb::generated::Node { labels, properties }
+    wasmcloud_actor_graphdb::generated::Node { labels, properties }
 }
 
 pub(crate) fn redisgraph_relation_to_common(
     rr: redisgraph::result_set::Relation,
-) -> actor_graphdb::generated::Relation {
+) -> wasmcloud_actor_graphdb::generated::Relation {
     let type_name = redisstring_to_string(rr.type_name);
     let properties = rr
         .properties
         .into_iter()
         .map(|(k, v)| (redisstring_to_string(k), redisgraph_scalar_to_common(v)))
         .collect::<HashMap<_, _>>();
-    actor_graphdb::generated::Relation {
+    wasmcloud_actor_graphdb::generated::Relation {
         type_name,
         properties,
     }

--- a/redisgraph/src/lib.rs
+++ b/redisgraph/src/lib.rs
@@ -7,11 +7,6 @@
 extern crate wascc_codec as codec;
 #[macro_use]
 extern crate log;
-use actor_core::CapabilityConfiguration;
-use actor_graphdb::{
-    deserialize, serialize, DeleteGraphArgs, DeleteResponse, QueryGraphArgs, QueryResponse,
-    OP_DELETE, OP_QUERY,
-};
 use codec::capabilities::{CapabilityProvider, Dispatcher, NullDispatcher};
 use codec::core::{OP_BIND_ACTOR, OP_REMOVE_ACTOR};
 use redis::Connection;
@@ -22,13 +17,17 @@ use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
 };
+use wasmcloud_actor_core::CapabilityConfiguration;
+use wasmcloud_actor_graphdb::{
+    deserialize, serialize, DeleteGraphArgs, DeleteResponse, QueryGraphArgs, QueryResponse,
+    OP_DELETE, OP_QUERY,
+};
 mod conversions;
 mod rgraph;
 
+#[allow(unused)]
 const CAPABILITY_ID: &str = "wasmcloud:graphdb";
 const SYSTEM_ACTOR: &str = "system";
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-const REVISION: u32 = 2; // Increment for each crates publish
 
 type GraphHandlerResult = Result<Vec<u8>, Box<dyn Error + Send + Sync + 'static>>;
 
@@ -134,14 +133,14 @@ impl RedisgraphProvider {
 // ResultSet type
 fn to_common_resultset(
     rs: redisgraph::ResultSet,
-) -> Result<actor_graphdb::ResultSet, Box<dyn Error + Send + Sync>> {
+) -> Result<wasmcloud_actor_graphdb::ResultSet, Box<dyn Error + Send + Sync>> {
     let columns = rs
         .columns
         .into_iter()
         .map(conversions::redisgraph_column_to_common)
         .collect::<Vec<_>>();
     let statistics = rs.statistics.0;
-    Ok(actor_graphdb::ResultSet {
+    Ok(wasmcloud_actor_graphdb::ResultSet {
         columns,
         statistics,
     })

--- a/redisgraph/src/rgraph.rs
+++ b/redisgraph/src/rgraph.rs
@@ -1,6 +1,6 @@
-use wasmcloud_actor_core::CapabilityConfiguration;
 use redisgraph::Graph;
 use std::error::Error;
+use wasmcloud_actor_core::CapabilityConfiguration;
 
 const ENV_REDIS_URL: &str = "URL";
 

--- a/redisgraph/src/rgraph.rs
+++ b/redisgraph/src/rgraph.rs
@@ -1,4 +1,4 @@
-use actor_core::CapabilityConfiguration;
+use wasmcloud_actor_core::CapabilityConfiguration;
 use redisgraph::Graph;
 use std::error::Error;
 

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-s3"
-version = "0.8.0"
+version = "0.9.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -32,8 +32,8 @@ rusoto_credential = "0.45.0"
 tokio = { version = "0.2.22", features = ["macros", "rt-threaded"]}
 futures = "0.3"
 bytes = "0.5"
-actor-core = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
-actor-blobstore = { git = "https://github.com/wasmcloud/actor-interfaces", branch = "main" }
+wasmcloud-actor-core = "0.2.0"
+wasmcloud-actor-blobstore = "0.1.0"
 
 [dev-dependencies]
 crossbeam = "0.7.3"

--- a/s3/src/lib.rs
+++ b/s3/src/lib.rs
@@ -8,8 +8,6 @@ extern crate wascc_codec as codec;
 #[macro_use]
 extern crate log;
 
-use actor_blobstore::*;
-use actor_core::CapabilityConfiguration;
 use codec::capabilities::{CapabilityProvider, Dispatcher, NullDispatcher};
 use codec::core::{OP_BIND_ACTOR, OP_REMOVE_ACTOR};
 use codec::{deserialize, serialize};
@@ -19,15 +17,16 @@ use std::{
     collections::HashMap,
     sync::{Arc, RwLock},
 };
+use wasmcloud_actor_blobstore::*;
+use wasmcloud_actor_core::CapabilityConfiguration;
 mod s3;
 
 #[cfg(not(feature = "static_plugin"))]
 capability_provider!(S3Provider, S3Provider::new);
 
+#[allow(unused)]
 const CAPABILITY_ID: &str = "wasmcloud:blobstore";
 const SYSTEM_ACTOR: &str = "system";
-const VERSION: &str = env!("CARGO_PKG_VERSION");
-const REVISION: u32 = 2; // Increment for each crates publish
 
 #[derive(Debug, PartialEq)]
 struct FileUpload {

--- a/s3/src/s3.rs
+++ b/s3/src/s3.rs
@@ -1,5 +1,5 @@
 use crate::FileUpload;
-use actor_core::CapabilityConfiguration;
+use wasmcloud_actor_core::CapabilityConfiguration;
 use futures::TryStreamExt;
 use rusoto_core::credential::{DefaultCredentialsProvider, StaticProvider};
 use rusoto_core::Region;

--- a/s3/src/s3.rs
+++ b/s3/src/s3.rs
@@ -1,5 +1,4 @@
 use crate::FileUpload;
-use wasmcloud_actor_core::CapabilityConfiguration;
 use futures::TryStreamExt;
 use rusoto_core::credential::{DefaultCredentialsProvider, StaticProvider};
 use rusoto_core::Region;
@@ -10,6 +9,7 @@ use rusoto_s3::{
     CreateBucketRequest, DeleteBucketRequest, DeleteObjectRequest, GetObjectRequest,
     HeadObjectRequest, ListObjectsV2Request, PutObjectRequest, S3Client, S3,
 };
+use wasmcloud_actor_core::CapabilityConfiguration;
 
 use std::error::Error;
 


### PR DESCRIPTION
This will allow us to re-release our capability providers, including a release to crates.io where they can be imported as libraries. 