### PR TITLE
Auto-updating README with crates.io versions, moved NATS comment

### DIFF
--- a/.github/workflows/nats-kvcache-release.yml
+++ b/.github/workflows/nats-kvcache-release.yml
@@ -1,0 +1,63 @@
+name: NATS-KVCACHE-RELEASE
+
+on:
+  push:
+    tags:
+    - 'nats-kvcache-v*'
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./nats-kvcache
+  REVISION: ${{ github.run_number }}
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{ env.working-directory }}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{ env.working-directory }}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{ env.working-directory }}
+
+  github_release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: true
+
+  crates_release:
+    needs: github_release
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Cargo login
+        env:
+          CRATES_TOKEN: ${{ secrets.CRATES_PUBLISH_TOKEN }}
+        run: cargo login ${{ env.CRATES_TOKEN }}
+      - name: Cargo publish
+        run: cargo publish --no-verify
+        working-directory: ${{ env.working-directory }}

--- a/.github/workflows/nats-kvcache.yml
+++ b/.github/workflows/nats-kvcache.yml
@@ -1,0 +1,40 @@
+name: NATS-KVCACHE
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+    - "nats-kvcache/**"
+  pull_request:
+    branches: [ main ]
+    paths:
+    - "nats-kvcache/**"
+
+env:
+  CARGO_TERM_COLOR: always
+  working-directory: ./nats-kvcache
+
+jobs:
+  cargo_check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Run tests
+      run: cargo test --verbose
+      working-directory: ${{env.working-directory}}
+    - name: Check fmt
+      run: cargo fmt -- --check
+      working-directory: ${{env.working-directory}}
+
+  clippy_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - run: rustup component add clippy
+      - name: Run cargo clippy
+        run: cargo clippy --all-features
+        working-directory: ${{env.working-directory}}
+

--- a/.github/workflows/nats-kvcache.yml
+++ b/.github/workflows/nats-kvcache.yml
@@ -16,18 +16,25 @@ env:
 
 jobs:
   cargo_check:
+    services:
+      nats:
+        image: nats
+        ports:
+          - 6222:6222
+          - 4222:4222
+          - 8222:8222
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - name: Build
       run: cargo build --verbose
-      working-directory: ${{env.working-directory}}
+      working-directory: ${{ env.working-directory }}
     - name: Run tests
       run: cargo test --verbose
-      working-directory: ${{env.working-directory}}
+      working-directory: ${{ env.working-directory }}
     - name: Check fmt
       run: cargo fmt -- --check
-      working-directory: ${{env.working-directory}}
+      working-directory: ${{ env.working-directory }}
 
   clippy_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/nats-release.yml
+++ b/.github/workflows/nats-release.yml
@@ -17,6 +17,13 @@ env:
 
 jobs:
   cargo_check:
+    services:
+      nats:
+        image: nats
+        ports:
+          - 6222:6222
+          - 4222:4222
+          - 8222:8222
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -20,6 +20,22 @@ cargo install --git https://github.com/ChrisRx/cross --branch add-darwin-target 
 
 MIPS-based architectures are not cross-compiled by default because some capability providers have dependencies that do not currently support MIPS. In particular, anything using [rustls](https://github.com/ctz/rustls) will not compile for MIPS-based architectures until [ring](https://github.com/briansmith/ring), a cryptography library that rustls depends on, fully [supports MIPS](https://github.com/briansmith/ring/issues/562).
 
+### Latest Versions
+| Capability Provider | Crate | Provider Archive OCI Reference |
+|---|---|---|
+| FS (File system) | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-fs) | wasmcloud.azurecr.io/fs |
+| HTTP Client | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-httpclient) | wasmcloud.azurecr.io/httpclient |
+| HTTP Server | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-httpserver) | wasmcloud.azurecr.io/httpserver |
+| Logging | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-logging) | wasmcloud.azurecr.io/logging |
+| NATS | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-nats) | wasmcloud.azurecr.io/nats |
+| Redis | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-redis) | wasmcloud.azurecr.io/redis |
+| Redis Streams | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-redisstreams) | wasmcloud.azurecr.io/redisstreams |
+| RedisGraph | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-redisgraph) | wasmcloud.azurecr.io/redisgraph |
+| S3 | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-s3) | wasmcloud.azurecr.io/s3 |
+| Telnet | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-telnet) | wasmcloud.azurecr.io/telnet |
+
+OCI reference tags match up exactly to the `crates.io` version, without the prefixed `v`. For example, if the `Logging` provider shows a `crates.io` version of `v0.9.0`, you can access the `Logging` provider archive at `wasmcloud.azurecr.io/logging:0.9.0`.
+
 ### Getting started
 
 You can cross-compile every provider running:

--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ MIPS-based architectures are not cross-compiled by default because some capabili
 ### Latest Versions
 | Capability Provider | Crate | Provider Archive OCI Reference |
 |---|---|---|
-| FS (File system) | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-fs) | wasmcloud.azurecr.io/fs |
-| HTTP Client | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-httpclient) | wasmcloud.azurecr.io/httpclient |
-| HTTP Server | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-httpserver) | wasmcloud.azurecr.io/httpserver |
-| Logging | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-logging) | wasmcloud.azurecr.io/logging |
-| NATS | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-nats) | wasmcloud.azurecr.io/nats |
-| Redis | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-redis) | wasmcloud.azurecr.io/redis |
-| Redis Streams | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-redisstreams) | wasmcloud.azurecr.io/redisstreams |
-| RedisGraph | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-redisgraph) | wasmcloud.azurecr.io/redisgraph |
-| S3 | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-s3) | wasmcloud.azurecr.io/s3 |
-| Telnet | ![Crates.io](https://img.shields.io/crates/v/wasmcloud-telnet) | wasmcloud.azurecr.io/telnet |
+| FS (File system) | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-fs)](https://crates.io/crates/wasmcloud-fs) | wasmcloud.azurecr.io/fs |
+| HTTP Client | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-httpclient)](https://crates.io/crates/wasmcloud-httpclient) | wasmcloud.azurecr.io/httpclient |
+| HTTP Server | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-httpserver)](https://crates.io/crates/wasmcloud-httpserver) | wasmcloud.azurecr.io/httpserver |
+| Logging | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-logging)](https://crates.io/crates/wasmcloud-logging) | wasmcloud.azurecr.io/logging |
+| NATS | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-nats)](https://crates.io/crates/wasmcloud-nats) | wasmcloud.azurecr.io/nats |
+| Redis | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-redis)](https://crates.io/crates/wasmcloud-redis) | wasmcloud.azurecr.io/redis |
+| Redis Streams | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-redisstreams)](https://crates.io/crates/wasmcloud-redisstreams) | wasmcloud.azurecr.io/redisstreams |
+| RedisGraph | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-redisgraph)](https://crates.io/crates/wasmcloud-redisgraph) | wasmcloud.azurecr.io/redisgraph |
+| S3 | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-s3)](https://crates.io/crates/wasmcloud-s3) | wasmcloud.azurecr.io/s3 |
+| Telnet | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-telnet)](https://crates.io/crates/wasmcloud-telnet) | wasmcloud.azurecr.io/telnet |
 
 OCI reference tags match up exactly to the `crates.io` version, without the prefixed `v`. For example, if the `Logging` provider shows a `crates.io` version of `v0.9.0`, you can access the `Logging` provider archive at `wasmcloud.azurecr.io/logging:0.9.0`.
 

--- a/fs/README.md
+++ b/fs/README.md
@@ -1,9 +1,9 @@
 [![crates.io](https://img.shields.io/crates/v/wasmcloud-fs.svg)](https://crates.io/crates/wasmcloud-fs)&nbsp;
-![Rust](https://github.com/wasmcloud/capability-providers/workflows/Rust/badge.svg)
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/FS/badge.svg)
 ![license](https://img.shields.io/crates/l/wasmcloud-fs.svg)&nbsp;
 [![documentation](https://docs.rs/wasmcloud-fs/badge.svg)](https://docs.rs/wasmcloud-fs)
 
-# File System Provider
+# wasmCloud File System Provider
 
 The **wasmCloud** File System provider is a capability provider for the `wasmcloud:blobstore` protocol. This generic protocol can be used to support capability providers like Amazon S3, Azure blob storage, Google blob storage, and more. This crate is an implementation of the protocol that operates on top of a designated root directory and can be used interchangeably with the larger cloud blob providers.
 

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-httpclient"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/capability-providers"

--- a/http-client/README.md
+++ b/http-client/README.md
@@ -1,2 +1,7 @@
-# HTTP Client Provider
-The HTTP Client provider allows wasmCloud actors to make outbound HTTP requests
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-httpclient.svg)](https://crates.io/crates/wasmcloud-httpclient)&nbsp;
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/HTTPCLIENT/badge.svg)
+![license](https://img.shields.io/crates/l/wasmcloud-httpclient.svg)&nbsp;
+[![documentation](https://docs.rs/wasmcloud-httpclient/badge.svg)](https://docs.rs/wasmcloud-httpclient)
+
+# wasmCloud HTTP Client Provider
+The HTTP Client provider allows wasmCloud actors to make outbound HTTP requests. Actors that use this capability provider to make HTTP requests must have a valid link to this provider and be signed with the `wasmcloud:httpclient` capability.

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-httpserver"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/http-server/README.md
+++ b/http-server/README.md
@@ -1,21 +1,21 @@
-[![crates.io](https://img.shields.io/crates/v/wascc-httpsrv.svg)](https://crates.io/crates/wascc-httpsrv)&nbsp;
-![Rust](https://github.com/wascc/http-server-provider/workflows/Rust/badge.svg)
-![license](https://img.shields.io/crates/l/wascc-httpsrv.svg)&nbsp;
-[![documentation](https://docs.rs/wascc-httpsrv/badge.svg)](https://docs.rs/wascc-httpsrv)
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-httpserver.svg)](https://crates.io/crates/wasmcloud-httpserver)&nbsp;
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/HTTPSERVER/badge.svg)
+![license](https://img.shields.io/crates/l/wasmcloud-httpserver.svg)&nbsp;
+[![documentation](https://docs.rs/wasmcloud-httpserver/badge.svg)](https://docs.rs/wasmcloud-httpserver)
 
-# waSCC HTTP Server Provider
+# wasmCloud HTTP Server Provider
 
 This library is a _native capability provider_ for the `wasmcloud:httpserver` capability. Only actors signed with tokens containing this capability privilege will be allowed to use it. 
 
-It should be compiled as a native shared object binary (linux `.so`, mac `.dylib`, windows `.dll`) and made available to the **waSCC** host runtime as a plugin. If you want to statically compile (embed) it into a custom waSCC host, then simply enable the `static_plugin` feature in your dependencies:
+It should be compiled as a native shared object binary (linux `.so`, mac `.dylib`, windows `.dll`) and made available to the **wasmCloud** host runtime as a plugin. If you want to statically compile (embed) it into a custom wasmCloud host, then simply enable the `static_plugin` feature in your dependencies:
 
 ```
-wascc-httpsrv = { version = "0.9.0", features = ["static_plugin"] }
+wasmCloud-httpserver = { version = "0.11.1", features = ["static_plugin"] }
 ```
 
-To create an actor that makes use of this capability provider, make sure that a configuration is supplied at runtime and includes a `PORT` variable. This will enable the HTTP server and direct _all_ requests to your actor module, which you can handle by checking that a dispatched operation is equivalent to the constant `OP_HANDLE_REQUEST`. For more information on the various types available to HTTP-based actors, check out the [schemas](https://github.com/wascc/schemas) repository.
+To create an actor that makes use of this capability provider, make sure that a configuration is supplied at runtime and includes a `PORT` variable. This will enable the HTTP server and direct _all_ requests to your actor module, which you can handle by checking that a dispatched operation is equivalent to the constant `OP_HANDLE_REQUEST`. For more information on the various types available to HTTP-based actors, check out the [actor-interfaces](https://github.com/wasmcloud/actor-interfaces) repository.
 
-For more hands-on tutorials on building actors, including HTTP server actors, see the [wascc.dev](https://wasc.dev) website.
+For more hands-on tutorials on building actors, including HTTP server actors, see the [wasmcloud.dev](https://wasmcloud.dev) website.
 
 **NOTE**: If multiple actors within the same host process request HTTP server configurations, 
 each actor will get its own HTTP server. Be careful not to request the same HTTP port for multiple actors in the same host process, as this will cause the host process to reject the configuration/binding.

--- a/http-server/README.md
+++ b/http-server/README.md
@@ -10,7 +10,7 @@ This library is a _native capability provider_ for the `wasmcloud:httpserver` ca
 It should be compiled as a native shared object binary (linux `.so`, mac `.dylib`, windows `.dll`) and made available to the **wasmCloud** host runtime as a plugin. If you want to statically compile (embed) it into a custom wasmCloud host, then simply enable the `static_plugin` feature in your dependencies:
 
 ```
-wasmCloud-httpserver = { version = "0.11.1", features = ["static_plugin"] }
+wasmcloud-httpserver = { version = "0.11.1", features = ["static_plugin"] }
 ```
 
 To create an actor that makes use of this capability provider, make sure that a configuration is supplied at runtime and includes a `PORT` variable. This will enable the HTTP server and direct _all_ requests to your actor module, which you can handle by checking that a dispatched operation is equivalent to the constant `OP_HANDLE_REQUEST`. For more information on the various types available to HTTP-based actors, check out the [actor-interfaces](https://github.com/wasmcloud/actor-interfaces) repository.

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-logging"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/logging/README.md
+++ b/logging/README.md
@@ -1,5 +1,5 @@
 [![crates.io](https://img.shields.io/crates/v/wasmcloud-logging.svg)](https://crates.io/crates/wasmcloud-logging)&nbsp;
-![Rust](https://github.com/wasmcloud/logging-provider/workflows/Rust/badge.svg)&nbsp;
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/LOGGING/badge.svg)&nbsp;
 ![license](https://img.shields.io/crates/l/wasmcloud-logging.svg)&nbsp;
 [![documentation](https://docs.rs/wasmcloud-logging/badge.svg)](https://docs.rs/wasmcloud-logging)
 

--- a/nats-kvcache/Cargo.toml
+++ b/nats-kvcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "nats-kvcache"
-version = "0.3.0"
+name = "wasmcloud-nats-kvcache"
+version = "0.4.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 license-file = "LICENSE.txt"

--- a/nats-kvcache/README.md
+++ b/nats-kvcache/README.md
@@ -1,4 +1,9 @@
-# NATS Distributed Key-Value Store
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-nats-kvcache.svg)](https://crates.io/crates/wasmcloud-nats-kvcache)
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/NATS-KVCACHE/badge.svg)
+![license](https://img.shields.io/crates/l/wasmcloud-nats-kvcache.svg)
+[![documentation](https://docs.rs/wasmcloud-nats-kvcache/badge.svg)](https://docs.rs/wasmcloud-nats-kvcache)
+
+# wasmCloud Key-Value Provider (NATS Distributed Key-Value Cache)
 
 This is an _in-memory_ key-value cache that is distributed by replicating state changes across a specific set of
 NATS topics. It is understood that in the "bare NATS" version of this provider, message loss can potentially happen

--- a/nats-kvcache/tests/integration.rs
+++ b/nats-kvcache/tests/integration.rs
@@ -2,13 +2,13 @@
 
 use std::{collections::HashMap, time::Duration};
 
-use nats_kvcache::NatsReplicatedKVProvider;
 use wascc_codec::{capabilities::CapabilityProvider, core::OP_BIND_ACTOR};
 use wasmcloud_actor_core::{deserialize, serialize, CapabilityConfiguration};
 use wasmcloud_actor_keyvalue::{
     AddArgs, GetArgs, GetResponse, SetAddArgs, SetQueryArgs, SetQueryResponse, OP_ADD, OP_GET,
     OP_SET_ADD, OP_SET_QUERY,
 };
+use wasmcloud_nats_kvcache::NatsReplicatedKVProvider;
 
 #[test]
 fn steadystate_and_replay() {

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud-nats"
 version = "0.10.1"
-authors = ["Kevin Hoffman <alothien@gmail.com>"]
+authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
 repository = "https://github.com/wasmcloud/capability-providers"

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-nats"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["Kevin Hoffman <alothien@gmail.com>"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/nats/README.md
+++ b/nats/README.md
@@ -1,4 +1,11 @@
-The waSCC NATS capability provider exposes publish and subscribe functionality to actors. The following configuration values can be passed to the waSCC host runtime for each actor binding:
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-nats.svg)](https://crates.io/crates/wasmcloud-nats)
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/NATS/badge.svg)
+![license](https://img.shields.io/crates/l/wasmcloud-nats.svg)
+[![documentation](https://docs.rs/wasmcloud-nats/badge.svg)](https://docs.rs/wasmcloud-nats)
+
+# wasmCloud NATS Provider
+
+The wasmCloud NATS capability provider exposes publish and subscribe functionality to actors. The following configuration values can be passed to the wasmCloud host runtime for each actor binding:
 
 * `SUBSCRIPTION` - The subscription string. This can contain wildcards. Use a comma-separated list for multiple subscriptions.
 * `QUEUEGROUP_NAME` - If you want all instances of the same actor to share round-robin delivery of messages, then set a unique queue group name for them. This queue group name will apply to all configured subscriptions.

--- a/nats/src/lib.rs
+++ b/nats/src/lib.rs
@@ -6,8 +6,8 @@ extern crate wasmcloud_actor_messaging as messaging;
 
 mod natsprov;
 
-#[allow(unused)]
-const CAPABILITY_ID: &str = "wasmcloud:messaging"; // used by the Makefile
+#[allow(unused)] // used by the Makefile
+const CAPABILITY_ID: &str = "wasmcloud:messaging";
 
 #[macro_use]
 extern crate log;

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-redis"
-version = "0.11.0"
+version = "0.11.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/redis/README.md
+++ b/redis/README.md
@@ -1,16 +1,16 @@
-[![crates.io](https://img.shields.io/crates/v/wascc-redis.svg)](https://crates.io/crates/wascc-redis)
-![Rust](https://github.com/wascc/redis-provider/workflows/Rust/badge.svg)
-![license](https://img.shields.io/crates/l/wascc-redis.svg)
-[![documentation](https://docs.rs/wascc-redis/badge.svg)](https://docs.rs/wascc-redis)
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-redis.svg)](https://crates.io/crates/wasmcloud-redis)
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/REDIS/badge.svg)
+![license](https://img.shields.io/crates/l/wasmcloud-redis.svg)
+[![documentation](https://docs.rs/wasmcloud-redis/badge.svg)](https://docs.rs/wasmcloud-redis)
 
-# waSCC Key-Value Provider (Redis)
+# wasmCloud Key-Value Provider (Redis)
 
-The waSCC Redis capability provider exposes an implementation of the key-value store interface built using Redis. Each actor module within a host runtime will be given its own unique Redis client connection. The following configuration parameters are accepted:
+The wasmCloud Redis capability provider exposes an implementation of the key-value store interface built using Redis. Each actor module within a host runtime will be given its own unique Redis client connection. The following configuration parameters are accepted:
 
 * `URL` - The connection string URL. This will default to `redis://0.0.0.0:6379` if a configuration is supplied without this value.
 
-If you want to statically link (embed) this plugin in a custom waSCC host rather than use it as a dynamic plugin, then enable the `static_plugin` feature in your dependencies section as shown:
+If you want to statically link (embed) this plugin in a custom wasmCloud host rather than use it as a dynamic plugin, then enable the `static_plugin` feature in your dependencies section as shown:
 
 ```
-wascc-redis = { version = "0.9.0", features = ["static_plugin"] }
+wasmcloud-redis = { version = "0.9.0", features = ["static_plugin"] }
 ```

--- a/redisgraph/Cargo.toml
+++ b/redisgraph/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "wasmcloud-redisgraph"
-version = "0.3.0"
-authors = ["Kevin Hoffman <alothien@gmail.com>"]
+version = "0.3.1"
+authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
 repository = "https://github.com/wasmcloud/capability-providers"

--- a/redisgraph/README.md
+++ b/redisgraph/README.md
@@ -1,6 +1,11 @@
-# Redis Graph - Graph Database Capability Provider
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-redisgraph.svg)](https://crates.io/crates/wasmcloud-redisgraph)
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/REDISGRAPH/badge.svg)
+![license](https://img.shields.io/crates/l/wasmcloud-redisgraph.svg)
+[![documentation](https://docs.rs/wasmcloud-redisgraph/badge.svg)](https://docs.rs/wasmcloud-redisgraph)
 
-This repository contains a shared library of [types and protocol definitions](./common), a [graph-guest](./graphguest) library that can be used by any actor that wants to consume _any_ graph database capability (not just RedisGraph), a [sample actor](./graph-actor), and the main capability provider [library](./wascc-redisgraph).
+# wasmCloud Graph Database Provider (Redis Graph)
+
+This repository contains a [sample actor](./examples/sample-graph-actor), and the main capability provider [library](./src).
 
 While the actor and common libraries should be usable across different types of graph databases, this provider is build on top of [Redis Graph](https://oss.redislabs.com/redisgraph/).
 

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-s3"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/s3/README.md
+++ b/s3/README.md
@@ -1,15 +1,14 @@
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-s3.svg)](https://crates.io/crates/wascc-s3)&nbsp;
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/S3/badge.svg)&nbsp;
+![license](https://img.shields.io/crates/l/wasmcloud-s3.svg)&nbsp;
+[![documentation](https://docs.rs/wasmcloud-s3/badge.svg)](https://docs.rs/wascc-s3)
 
-[![crates.io](https://img.shields.io/crates/v/wascc-s3.svg)](https://crates.io/crates/wascc-s3)&nbsp;
-![Rust](https://github.com/wascc/s3-provider/workflows/Rust/badge.svg)&nbsp;
-![license](https://img.shields.io/crates/l/wascc-s3.svg)&nbsp;
-[![documentation](https://docs.rs/wascc-s3/badge.svg)](https://docs.rs/wascc-s3)
+# wasmCloud Blobstore Provider (S3)
 
-# waSCC S3 Capability Provider
-
-A native capability provider for waSCC that implements the `wascc:blobstore` protocol for Amazon S3 and S3-compliant (e.g. `minio`) storage servers.
+A native capability provider for wasmCloud that implements the `wasmcloud:blobstore` protocol for Amazon S3 and S3-compliant (e.g. `minio`) storage servers.
 
 If you want to statically compile (embed) this plugin into a custom host, then enable the `static_plugin` feature in your dependencies:
 
 ```
-wascc-s3 = { version = "??", features = ["static_plugin"]}
+wasmcloud-s3 = { version = "??", features = ["static_plugin"]}
 ```


### PR DESCRIPTION
Apparently, our script to grab the capability contract ID does not handle comments on the same line, so I moved the NATS comment up a line.

The main feature of this PR is `crates.io` badges for the latest versions in the readme, this ensures anyone who visits this repository can automatically see the latest published crate version. I threw in a snippet about the latest OCI tag, but the OCI reference is there at least without the tag. Curious if there are suggested improvements.

I've also trawled through our READMEs and removed some lingering `wascc` references, added crates.io badges, and standardized the format of the READMEs. This will make the crates.io page look similar for all the providers and show accurate information.