### PR TITLE
Bumping NATS kvcache to provider core

### DIFF
--- a/nats-kvcache/Cargo.toml
+++ b/nats-kvcache/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-nats-kvcache"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 license-file = "LICENSE.txt"
@@ -31,8 +31,8 @@ static_plugin = []
 wasmcloud-actor-keyvalue = "0.2.0"
 wasmcloud-actor-core = "0.2.0"
 nats = "0.8.6"
-wascc-codec = "0.9.0"
-wascap = "0.5.1"
+wasmcloud-provider-core = "0.1.0"
+wascap = "0.6.0"
 env_logger = "0.8.2"
 uuid = { version = "0.8.1", features = ["v4"] }
 lazy_static = "1.4.0"

--- a/nats-kvcache/src/lib.rs
+++ b/nats-kvcache/src/lib.rs
@@ -33,16 +33,14 @@ extern crate eventsourcing;
 extern crate wasmcloud_actor_core as core;
 extern crate wasmcloud_actor_keyvalue as keyvalue;
 #[macro_use]
-extern crate wascc_codec as codec;
+extern crate wasmcloud_provider_core as codec;
 #[macro_use]
 extern crate log;
 use crossbeam_channel::{select, tick, Receiver, Sender};
 
-use codec::capabilities::{
-    CapabilityProvider, Dispatcher, NullDispatcher, OP_GET_CAPABILITY_DESCRIPTOR,
-};
+use codec::capabilities::{CapabilityProvider, Dispatcher, NullDispatcher};
+use codec::core::SYSTEM_ACTOR;
 use codec::core::{OP_BIND_ACTOR, OP_HEALTH_REQUEST, OP_REMOVE_ACTOR};
-use codec::SYSTEM_ACTOR;
 use core::{CapabilityConfiguration, HealthCheckResponse};
 use events::{Cache, CacheData, CacheEventWrapper};
 use eventsourcing::Aggregate;
@@ -528,7 +526,6 @@ impl CapabilityProvider for NatsReplicatedKVProvider {
             OP_BIND_ACTOR if actor == SYSTEM_ACTOR => self.configure(deserialize(msg)?),
             OP_REMOVE_ACTOR if actor == SYSTEM_ACTOR => self.remove_actor(deserialize(msg)?),
             OP_HEALTH_REQUEST if actor == SYSTEM_ACTOR => self.health(),
-            OP_GET_CAPABILITY_DESCRIPTOR if actor == SYSTEM_ACTOR => Ok(vec![]), // Descriptors are no longer used
             keyvalue::OP_ADD => self.add(actor, deserialize(msg)?),
             keyvalue::OP_DEL => self.del(actor, deserialize(msg)?),
             keyvalue::OP_GET => self.get(actor, deserialize(msg)?),

--- a/nats-kvcache/tests/integration.rs
+++ b/nats-kvcache/tests/integration.rs
@@ -1,8 +1,8 @@
 // *** This test requires a running NATS server
 
 use std::{collections::HashMap, time::Duration};
-
-use wascc_codec::{capabilities::CapabilityProvider, core::OP_BIND_ACTOR};
+extern crate wasmcloud_provider_core as codec;
+use codec::{capabilities::CapabilityProvider, core::OP_BIND_ACTOR};
 use wasmcloud_actor_core::{deserialize, serialize, CapabilityConfiguration};
 use wasmcloud_actor_keyvalue::{
     AddArgs, GetArgs, GetResponse, SetAddArgs, SetQueryArgs, SetQueryResponse, OP_ADD, OP_GET,


### PR DESCRIPTION
When fixing clippy warnings in wasmcloud-host PR, decided to bump wasmcloud-host to use provider core instead of wascc-codec. This meant that I needed the NATS kvcache to use provider core ;)