### PR TITLE
🤬🤬🤬🤬

### DIFF
--- a/redis-streams/Cargo.toml
+++ b/redis-streams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-streams-redis"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/redis-streams/src/lib.rs
+++ b/redis-streams/src/lib.rs
@@ -91,10 +91,10 @@ impl RedisStreamsProvider {
     fn write_event(
         &self,
         actor: &str,
-        event: Event,
+        args: WriteEventArgs,
     ) -> Result<Vec<u8>, Box<dyn Error + Sync + Send>> {
-        let data = map_to_tuples(event.values);
-        let ack = match self.actor_con(actor)?.xadd(event.stream_id, "*", &data) {
+        let data = map_to_tuples(args.values);
+        let ack = match self.actor_con(actor)?.xadd(args.stream_id, "*", &data) {
             Ok(res) => EventAck {
                 error: None,
                 event_id: Some(res),
@@ -250,8 +250,7 @@ mod test {
         prov.configure(config).unwrap();
 
         for _ in 0..6 {
-            let ev = Event {
-                event_id: "".to_string(),
+            let ev = WriteEventArgs {
                 stream_id: "my-stream".to_string(),
                 values: gen_values(),
             };


### PR DESCRIPTION
This version was still de-serializing the data as an event, not as a `WriteEventArgs`