### PR TITLE
Blobstore provider update

### DIFF
--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-fs"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -22,7 +22,7 @@ static_plugin = []
 [dependencies]
 log = "0.4.14"
 env_logger = "0.7.1"
-wasmcloud-actor-blobstore = "0.1.0"
+wasmcloud-actor-blobstore = "0.2.0"
 wasmcloud-actor-core = "0.2.0"
 
 [dependencies.wasmcloud-provider-core]

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -104,16 +104,16 @@ impl FileSystemProvider {
         };
         let blob = sanitize_blob(&blob);
         let bfile = self.blob_to_path(&blob);
-        serialize(match std::fs::write(bfile, &[]) {
-            Ok(_) => BlobstoreResult {
-                success: true,
-                error: None,
-            },
-            Err(e) => BlobstoreResult {
+        serialize(std::fs::write(bfile, &[]).map_or_else(
+            |e| BlobstoreResult {
                 success: false,
                 error: Some(e.to_string()),
             },
-        })
+            |_| BlobstoreResult {
+                success: true,
+                error: None,
+            },
+        ))
     }
 
     fn remove_object(
@@ -123,16 +123,16 @@ impl FileSystemProvider {
     ) -> Result<Vec<u8>, Box<dyn Error + Sync + Send>> {
         let blob = sanitize_blob(&blob);
         let bfile = self.blob_to_path(&blob);
-        serialize(match std::fs::remove_file(&bfile) {
-            Ok(_) => BlobstoreResult {
-                success: true,
-                error: None,
-            },
-            Err(e) => BlobstoreResult {
+        serialize(std::fs::remove_file(&bfile).map_or_else(
+            |e| BlobstoreResult {
                 success: false,
                 error: Some(e.to_string()),
             },
-        })
+            |_| BlobstoreResult {
+                success: true,
+                error: None,
+            },
+        ))
     }
 
     fn get_object_info(

--- a/fs/src/lib.rs
+++ b/fs/src/lib.rs
@@ -354,7 +354,7 @@ impl CapabilityProvider for FileSystemProvider {
         op: &str,
         msg: &[u8],
     ) -> Result<Vec<u8>, Box<dyn Error + Sync + Send>> {
-        info!("Received host call from {}, operation - {}", actor, op);
+        trace!("Received host call from {}, operation - {}", actor, op);
 
         match op {
             OP_BIND_ACTOR if actor == SYSTEM_ACTOR => self.configure(deserialize(msg)?),

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-s3"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"
@@ -32,7 +32,7 @@ tokio = { version = "1.3", features = ["macros", "rt-multi-thread"]}
 futures = "0.3"
 bytes = "1.0"
 wasmcloud-actor-core = "0.2.0"
-wasmcloud-actor-blobstore = "0.1.0"
+wasmcloud-actor-blobstore = "0.2.0"
 
 [dependencies.wasmcloud-provider-core]
 version = "0.1.0"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -31,6 +31,9 @@ rusoto_credential = "0.46.0"
 tokio = { version = "1.3", features = ["macros", "rt-multi-thread"]}
 futures = "0.3"
 bytes = "1.0"
+hyper-proxy = "0.9.0"
+hyper = { version = "0.14.0", features = ["runtime"] }
+hyper-tls = "0.5.0"
 wasmcloud-actor-core = "0.2.0"
 wasmcloud-actor-blobstore = "0.2.0"
 

--- a/s3/README.md
+++ b/s3/README.md
@@ -1,7 +1,7 @@
-[![crates.io](https://img.shields.io/crates/v/wasmcloud-s3.svg)](https://crates.io/crates/wascc-s3)&nbsp;
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-s3.svg)](https://crates.io/crates/wasmcloud-s3)&nbsp;
 ![Rust](https://github.com/wasmcloud/capability-providers/workflows/S3/badge.svg)&nbsp;
 ![license](https://img.shields.io/crates/l/wasmcloud-s3.svg)&nbsp;
-[![documentation](https://docs.rs/wasmcloud-s3/badge.svg)](https://docs.rs/wascc-s3)
+[![documentation](https://docs.rs/wasmcloud-s3/badge.svg)](https://docs.rs/wasmcloud-s3)
 
 # wasmCloud Blobstore Provider (S3)
 
@@ -12,3 +12,14 @@ If you want to statically compile (embed) this plugin into a custom host, then e
 ```
 wasmcloud-s3 = { version = "??", features = ["static_plugin"]}
 ```
+
+## Configuration Values
+| Value | Description |
+| ----------- | ----------- |
+| REGION | AWS region to use (default `us-east-1`) |
+| ENDPOINT | AWS endpoint to use (default `s3.us-east-1.amazonaws.com` |
+| AWS_ACCESS_KEY | AWS access key for authentication |
+| AWS_SECRET_ACCESS_KEY | AWS secret access key for authentication |
+| AWS_TOKEN | AWS token for authentication (can be omitted if not needed for auth) |
+| TOKEN_VALID_FOR | AWS token lifetime (in seconds)|
+| HTTP_PROXY | Proxy URL to use with the S3 client |

--- a/s3/src/lib.rs
+++ b/s3/src/lib.rs
@@ -108,19 +108,20 @@ impl S3Provider {
     ) -> Result<Vec<u8>, Box<dyn Error + Sync + Send>> {
         let rt = tokio::runtime::Runtime::new().unwrap();
         serialize(
-            match rt.block_on(s3::remove_bucket(
+            rt.block_on(s3::remove_bucket(
                 &self.clients.read().unwrap()[actor],
                 &container.id,
-            )) {
-                Ok(_) => BlobstoreResult {
-                    success: true,
-                    error: None,
-                },
-                Err(e) => BlobstoreResult {
+            ))
+            .map_or_else(
+                |e| BlobstoreResult {
                     success: false,
                     error: Some(e.to_string()),
                 },
-            },
+                |_| BlobstoreResult {
+                    success: true,
+                    error: None,
+                },
+            ),
         )
     }
 
@@ -179,20 +180,21 @@ impl S3Provider {
     ) -> Result<Vec<u8>, Box<dyn Error + Sync + Send>> {
         let rt = tokio::runtime::Runtime::new().unwrap();
         serialize(
-            match rt.block_on(s3::remove_object(
+            rt.block_on(s3::remove_object(
                 &self.clients.read().unwrap()[actor],
                 &blob.container.id,
                 &blob.id,
-            )) {
-                Ok(_) => BlobstoreResult {
-                    success: true,
-                    error: None,
-                },
-                Err(e) => BlobstoreResult {
+            ))
+            .map_or_else(
+                |e| BlobstoreResult {
                     success: false,
                     error: Some(e.to_string()),
                 },
-            },
+                |_| BlobstoreResult {
+                    success: true,
+                    error: None,
+                },
+            ),
         )
     }
 

--- a/s3/src/s3.rs
+++ b/s3/src/s3.rs
@@ -154,10 +154,7 @@ pub(crate) async fn complete_upload(
         ..Default::default()
     };
 
-    log::info!("putting object");
-    let res = client.put_object(put_request).await;
-    log::info!("putting object: {:?}", res);
-    res.unwrap();
+    client.put_object(put_request).await?;
     Ok(())
 }
 

--- a/s3/src/s3.rs
+++ b/s3/src/s3.rs
@@ -47,13 +47,12 @@ pub(crate) fn client_for_config(
                 .get("TOKEN_VALID_FOR")
                 .map(|t| t.parse::<i64>().unwrap()),
         );
-        let http_proxy = config.values["HTTP_PROXY"].to_string();
-        let connector: HttpConnector = if http_proxy.is_empty() {
-            ProxyConnector::new(HttpsConnector::new())?
-        } else {
+        let connector: HttpConnector = if let Some(proxy) = config.values.get("HTTP_PROXY") {
             info!("Proxy enabled for S3 client");
-            let proxy = Proxy::new(Intercept::All, http_proxy.parse::<Uri>()?);
+            let proxy = Proxy::new(Intercept::All, proxy.parse::<Uri>()?);
             ProxyConnector::from_proxy(hyper_tls::HttpsConnector::new(), proxy)?
+        } else {
+            ProxyConnector::new(HttpsConnector::new())?
         };
         let mut hyper_builder: hyper::client::Builder = Client::builder();
         // disabling due to connection closed issue

--- a/s3/src/s3.rs
+++ b/s3/src/s3.rs
@@ -1,5 +1,9 @@
 use crate::FileUpload;
 use futures::TryStreamExt;
+use hyper::{Client, Uri};
+use hyper_proxy::{Intercept, Proxy, ProxyConnector};
+use hyper_tls::HttpsConnector;
+use log::info;
 use rusoto_core::credential::{DefaultCredentialsProvider, StaticProvider};
 use rusoto_core::Region;
 use rusoto_s3::HeadObjectOutput;
@@ -12,6 +16,9 @@ use rusoto_s3::{
 use wasmcloud_actor_core::CapabilityConfiguration;
 
 use std::error::Error;
+
+type HttpConnector =
+    hyper_proxy::ProxyConnector<hyper_tls::HttpsConnector<hyper::client::HttpConnector>>;
 
 pub(crate) fn client_for_config(
     config: &CapabilityConfiguration,
@@ -30,6 +37,7 @@ pub(crate) fn client_for_config(
     };
 
     let client = if config.values.contains_key("AWS_ACCESS_KEY") {
+        info!("Creating provider from provided keys");
         let provider = StaticProvider::new(
             config.values["AWS_ACCESS_KEY"].to_string(),
             config.values["AWS_SECRET_ACCESS_KEY"].to_string(),
@@ -39,12 +47,21 @@ pub(crate) fn client_for_config(
                 .get("TOKEN_VALID_FOR")
                 .map(|t| t.parse::<i64>().unwrap()),
         );
-        S3Client::new_with(
-            rusoto_core::request::HttpClient::new().expect("Failed to create HTTP client"),
-            provider,
-            region,
-        )
+        let http_proxy = config.values["HTTP_PROXY"].to_string();
+        let connector: HttpConnector = if http_proxy.is_empty() {
+            ProxyConnector::new(HttpsConnector::new())?
+        } else {
+            info!("Proxy enabled for S3 client");
+            let proxy = Proxy::new(Intercept::All, http_proxy.parse::<Uri>()?);
+            ProxyConnector::from_proxy(hyper_tls::HttpsConnector::new(), proxy)?
+        };
+        let mut hyper_builder: hyper::client::Builder = Client::builder();
+        // disabling due to connection closed issue
+        hyper_builder.pool_max_idle_per_host(0);
+        let client = rusoto_core::HttpClient::from_builder(hyper_builder, connector);
+        S3Client::new_with(client, provider, region)
     } else {
+        info!("Creating provider with default credentials");
         let provider = DefaultCredentialsProvider::new()?;
         S3Client::new_with(
             rusoto_core::request::HttpClient::new().expect("Failed to create HTTP client"),
@@ -137,7 +154,10 @@ pub(crate) async fn complete_upload(
         ..Default::default()
     };
 
-    client.put_object(put_request).await?;
+    log::info!("putting object");
+    let res = client.put_object(put_request).await;
+    log::info!("putting object: {:?}", res);
+    res.unwrap();
     Ok(())
 }
 


### PR DESCRIPTION
Both blobstore providers (fs, s3) needed to update to the blobstore interface version `0.2.0`, mostly just to return the `BlobstoreResult` for a few operations.

While I was updating and testing the s3 provider, I added in an option to use an HTTP proxy, which is common in enterprise AWS environments. This should not affect any existing configurations as it's strictly optional.