### PR TITLE
Brought telnet provider up to 0.15.0 standards

### DIFF
--- a/telnet/Cargo.toml
+++ b/telnet/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "wasmcloud-telnet"
-version = "0.1.1"
-authors = ["Kevin Hoffman <alothien@gmail.com>"]
+version = "0.1.2"
+authors = ["wasmCloud Team"]
 edition = "2018"
-homepage = "https://wascc.dev"
-repository = "https://github.com/wascc/telnet-provider"
-description = "A telnet server capability provider for waSCC actors"
+homepage = "https://wasmcloud.dev"
+repository = "https://github.com/wasmcloud/capability-providers"
+description = "A telnet server capability provider for wasmCloud actors"
 license = "Apache-2.0"
-documentation = "https://docs.rs/wascc-telnet"
+documentation = "https://docs.rs/wasmcloud-telnet"
 readme = "README.md"
-keywords = ["webassembly", "wasm", "telnet", "wascc"]
+keywords = ["webassembly", "wasm", "telnet", "wasmcloud"]
 categories = ["wasm", "api-bindings", "network-programming"]
 
 [lib]
@@ -18,7 +18,6 @@ crate-type = ["cdylib", "rlib"]
 [features]
 # Enable if the provider will be statically compiled into a host
 static_plugin = []
-
 
 [dependencies]
 log = "0.4.14"
@@ -34,3 +33,7 @@ wasmcloud-actor-core = "0.2.2"
 [dependencies.wasmcloud-provider-core]
 version = "0.1.0"
 #path = "../../wasmcloud/crates/wasmcloud-provider-core"
+
+[dependencies.wasmcloud-actor-telnet]
+version = "0.1.2"
+#path = "../../actor-interfaces/telnet/rust"

--- a/telnet/README.md
+++ b/telnet/README.md
@@ -1,4 +1,9 @@
-# Telnet Capability Provider
+[![crates.io](https://img.shields.io/crates/v/wasmcloud-telnet.svg)](https://crates.io/crates/wasmcloud-telnet)&nbsp;
+![Rust](https://github.com/wasmcloud/capability-providers/workflows/TELNET/badge.svg)&nbsp;
+![license](https://img.shields.io/crates/l/wasmcloud-telnet.svg)&nbsp;
+[![documentation](https://docs.rs/wasmcloud-telnet/badge.svg)](https://docs.rs/wasmcloud-telnet)
+
+# wasmCloud Telnet Capability Provider
 
 The telnet capability provider will start a new telnet (socket) server for each actor that binds to it, using the following configuration variables from the binding:
 


### PR DESCRIPTION
Fixes #32, Fixes #12 

This PR brings the `telnet` provider up to `0.15.0` standards, including making use of the `telnet` actor interface, idempotent `bind` functionality, and properly removing listeners when actors are Removed.

Speaking to the last point, I wasn't able to get the `RemoveActor` op to be delivered to this provider. Perhaps @autodidaddict can shed some light on if this should happen when I run `wash ctl stop actor`, `wash ctl stop provider`, or if it only is delivered in another case.