### PR TITLE
Blobstore interface parity

### DIFF
--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-fs"
-version = "0.3.3"
+version = "0.4.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -24,12 +24,12 @@ crate-type = ["cdylib", "rlib"]
 [dependencies]
 rmp-serde = "0.15.4"
 serde_bytes = "0.11.5"
-serde = {version = "1.0.124", features = ["derive"] }
-actix-web = "4.0.0-beta.4"
+serde = { version = "1.0.124", features = ["derive"] }
+actix-web = "3.3.2"
 actix-rt = "2.1.0"
 env_logger = "0.8.3"
 log = "0.4.14"
-tokio = { version="1.3", features=["rt"]}
+tokio = { version="1.3", features=["rt"] }
 wasmcloud-actor-http-server = "0.1.0"
 wasmcloud-actor-core = "0.2.0"
 

--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -199,7 +199,7 @@ impl TryFrom<&str> for ModuleId {
 }
 
 impl CapabilityProvider for HttpServerProvider {
-    /// Accepts the dispatcher provided by the waSCC host runtime
+    /// Accepts the dispatcher provided by the wasmCloud host runtime
     fn configure_dispatch(
         &self,
         dispatcher: Box<dyn Dispatcher>,

--- a/redisgraph/examples/sample-graph-actor/Makefile
+++ b/redisgraph/examples/sample-graph-actor/Makefile
@@ -28,7 +28,7 @@ bench:
 
 build:
 	@$(CARGO) build
-	wascap sign $(DEBUG)/graph_actor.wasm $(DEBUG)/graph_actor_signed.wasm -i $(KEYDIR)/account.nk -u $(KEYDIR)/module.nk -s -c wascc:graphdb -n "Graph DB Actor"
+	wascap sign $(DEBUG)/graph_actor.wasm $(DEBUG)/graph_actor_signed.wasm -i $(KEYDIR)/account.nk -u $(KEYDIR)/module.nk -s -c wasmcloud:graphdb -n "Graph DB Actor"
 
 check:
 	@$(CARGO) check
@@ -47,7 +47,7 @@ update:
 
 release:
 	@$(CARGO) build --release
-	wascap sign $(RELEASE)/graph_actor.wasm $(RELEASE)/graph_actor_signed.wasm -i $(KEYDIR)/account.nk -u $(KEYDIR)/module.nk -s -c wascc:graphdb -n "Graph DB Actor"
+	wascap sign $(RELEASE)/graph_actor.wasm $(RELEASE)/graph_actor_signed.wasm -i $(KEYDIR)/account.nk -u $(KEYDIR)/module.nk -s -c wasmcloud:graphdb -n "Graph DB Actor"
 	
 keys: keys-account
 keys: keys-module

--- a/redisgraph/examples/sample-graph-actor/README.md
+++ b/redisgraph/examples/sample-graph-actor/README.md
@@ -1,17 +1,21 @@
 # New Actor Template
 
-Use cargo generate to create a new actor module from this template.
+Use cargo generate to create a new actor module from this template:
 
-[Learn how to write](https://wascc.dev/tutorials/first-actor/) waSCC actors, or [explore the actor concept](https://wascc.dev/docs/concepts/actors/).
+```
+cargo generate --git https://github.com/wasmcloud/new-actor-template --branch main
+```
 
-To generate new keys, use `make keys`. This will use `nk` to generate both sets of keys for you, and then write them to the `.keys` directory.
+Use the `wash` CLI to sign your WebAssembly module after you have created it. The `Makefile` created by this template will sign your module for you with `make build` and `make release`.
 
-To build your new module, use `make build`. This will compile your code with `cargo`, and then sign it with `wascap` using the keys in `.keys`.
+You should modify this `Makefile` after creation to have the right actor name, revision, tags, and claims.
 
 ## Tool Requirements
 
 - Cargo and Rust are required
 - Make is recommended, but not strictly necessary
-- [wascap](https://github.com/wascc/wascap) is required for signing actor modules
-- [nk](https://github.com/encabulators/nkeys) is required if you need to generate keys (which you almost certainly do)
+- [wash](https://github.com/wasmcloud/wash) - wasmcloud's multi-purpose CLI
 
+### Note
+
+The `Makefile` will use keys that are generated _locally_ for you. Once you move this actor into a pipeline toward a production deployment, you will want to explicitly specify the key locations and disable key generation in `wash` with the `--disable-keygen` option.

--- a/redisgraph/graphdemo_manifest.yaml
+++ b/redisgraph/graphdemo_manifest.yaml
@@ -1,4 +1,4 @@
-# Use this file in conjunction with the generic wascc-host binary to launch a
+# Use this file in conjunction with the wasmcloud binary to launch a
 # demonstration of the graph database capability provider. 
 # You'll need to launch redisgraph, easiest way to do that is with
 # this docker command:
@@ -11,17 +11,23 @@
 # $ curl -X POST localhost:8081 (creates nodes/edges)
 # $ curl localhost:8081 (retrieves some data in a sample query)
 ---
+labels:
+    sample: "wasmCloud GraphDB Example"
 actors:
     - ./graph-actor/target/wasm32-unknown-unknown/release/graph_actor_signed.wasm
 capabilities:
-    - path: ./wascc-redisgraph/target/release/libwascc_redisgraph.so
-    - path: ../wascc-host/examples/.assets/libwascc_httpsrv.so
-bindings:
+    - image_ref: wasmcloud.azurecr.io/redisgraph:0.3.2
+      link_name: default
+    - path: wasmcloud.azurecr.io/httpserver:0.12.1
+      link_name: default
+links:
     - actor: "MDSY2N2ALHIPBOL6W44KMOIHHKPD4CAMJMWAGXEIAHTPS7LLYQKSFZ2L"
-      capability: "wascc:graphdb"
+      contract_id: "wasmcloud:graphdb"
+      provider_id: "VDBU6VAJ6JSUEE6GCW7V37I6QN7NBR2Z3I4ZWCCSNMDDXYFGVCS2FHEG"
       values:
         URL: redis://127.0.0.1:6379
     - actor: "MDSY2N2ALHIPBOL6W44KMOIHHKPD4CAMJMWAGXEIAHTPS7LLYQKSFZ2L"
-      capability: "wascc:http_server"
+      contract_id: "wasmcloud:http_server"
+      provider_id: "VAG3QITQQ2ODAOWB5TTQSDJ53XK3SHBEIFNK4AYJ5RKAX2UNSCAPHA5M"
       values:
         PORT: "8081"

--- a/redisgraph/src/lib.rs
+++ b/redisgraph/src/lib.rs
@@ -1,6 +1,6 @@
-//! # RedisGraph implementation of the waSCC Graph Database Capability Provider API
+//! # RedisGraph implementation of the wasmCloud Graph Database Capability Provider API
 //!
-//! Provides an implementation of the wascc:graphdb contract for RedisGraph
+//! Provides an implementation of the wasmcloud:graphdb contract for RedisGraph
 //! using the Cypher language
 
 use codec::{

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-s3"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/s3/src/lib.rs
+++ b/s3/src/lib.rs
@@ -41,7 +41,7 @@ impl FileUpload {
     }
 }
 
-/// AWS S3 implementation of the `wascc:blobstore` specification
+/// AWS S3 implementation of the `wasmcloud:blobstore` specification
 #[derive(Clone)]
 pub struct S3Provider {
     dispatcher: Arc<RwLock<Box<dyn Dispatcher>>>,


### PR DESCRIPTION
Fixes #63 

With our `widl` wrapper object changes, some of the parameters for the blobstore provider functions were not the same type as the interface specifies. This PR remediates that.