### PR TITLE
Update actions, re-release for aarch64-apple-darwin

### DIFF
--- a/.github/workflows/TEMPLATE_provider-release.yml
+++ b/.github/workflows/TEMPLATE_provider-release.yml
@@ -10,7 +10,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./provider
-  DESTINATION: provider.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_PROVIDER }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -85,6 +84,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/provider:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/fs-release.yml
+++ b/.github/workflows/fs-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./fs
-  DESTINATION: fs.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_FS }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -84,6 +83,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/fs:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/httpclient-release.yml
+++ b/.github/workflows/httpclient-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./http-client
-  DESTINATION: httpclient.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_HTTPCLIENT }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -84,6 +83,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/httpclient:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/httpserver-release.yml
+++ b/.github/workflows/httpserver-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./http-server
-  DESTINATION: httpserver.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_HTTPSERVER }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -84,6 +83,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/httpserver:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/logging-release.yml
+++ b/.github/workflows/logging-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./logging
-  DESTINATION: logging.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_LOGGING }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -84,6 +83,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/logging:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/nats-release.yml
+++ b/.github/workflows/nats-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./nats
-  DESTINATION: nats.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_NATS }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -91,6 +90,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/nats:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redis-release.yml
+++ b/.github/workflows/redis-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./redis
-  DESTINATION: redis.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_REDIS }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -84,6 +83,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/redis:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redisgraph-release.yml
+++ b/.github/workflows/redisgraph-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./redisgraph
-  DESTINATION: redisgraph.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_REDISGRAPH }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -84,6 +83,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/redisgraph:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redisstreams-release.yml
+++ b/.github/workflows/redisstreams-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./redis-streams
-  DESTINATION: redisstreams.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_REDISSTREAMS }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -96,6 +95,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/redisstreams:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/s3-release.yml
+++ b/.github/workflows/s3-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./s3
-  DESTINATION: s3.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_S3 }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -89,6 +88,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/s3:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/telnet-release.yml
+++ b/.github/workflows/telnet-release.yml
@@ -8,7 +8,6 @@ on:
 env:
   CARGO_TERM_COLOR: always
   working-directory: ./telnet
-  DESTINATION: telnet.par.gz #aka the filename of the parJEEzy
   WASH_ISSUER_KEY: ${{ secrets.WASMCLOUD_ACCOUNT_OFFICIAL }}
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_TELNET }}
   WASH_REG_USER:  ${{ secrets.AZURECR_PUSH_USER }}
@@ -84,6 +83,7 @@ jobs:
       - name: push-par
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
-          URL=${{secrets.AZURECR_PUSH_URL}}/telnet:$VERSION
-          wash reg push $URL ${{ env.DESTINATION }}
+          NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -22,7 +22,7 @@ static_plugin = []
 [dependencies]
 log = "0.4.14"
 env_logger = "0.7.1"
-wasmcloud-actor-blobstore = "0.2.0"
+wasmcloud-actor-blobstore = "0.2.2"
 wasmcloud-actor-core = "0.2.0"
 
 [dependencies.wasmcloud-provider-core]

--- a/fs/Cargo.toml
+++ b/fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-fs"
-version = "0.4.0"
+version = "0.4.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/http-client/Cargo.toml
+++ b/http-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-httpclient"
-version = "0.2.3"
+version = "0.2.4"
 authors = ["wasmCloud Team"]
 edition = "2018"
 repository = "https://github.com/wasmcloud/capability-providers"

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-httpserver"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/logging/Cargo.toml
+++ b/logging/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-logging"
-version = "0.9.3"
+version = "0.9.4"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-nats"
-version = "0.10.3"
+version = "0.10.4"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/redis-streams/Cargo.toml
+++ b/redis-streams/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-streams-redis"
-version = "0.5.2"
+version = "0.5.3"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/redis/Cargo.toml
+++ b/redis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-redis"
-version = "0.11.2"
+version = "0.11.3"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/redisgraph/Cargo.toml
+++ b/redisgraph/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-redisgraph"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -35,7 +35,7 @@ hyper-proxy = "0.9.0"
 hyper = { version = "0.14.0", features = ["runtime"] }
 hyper-tls = "0.5.0"
 wasmcloud-actor-core = "0.2.0"
-wasmcloud-actor-blobstore = "0.2.0"
+wasmcloud-actor-blobstore = "0.2.2"
 
 [dependencies.wasmcloud-provider-core]
 version = "0.1.0"

--- a/s3/Cargo.toml
+++ b/s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-s3"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"

--- a/telnet/Cargo.toml
+++ b/telnet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-telnet"
-version = "0.1.2"
+version = "0.1.3"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"


### PR DESCRIPTION
This PR updates the actions for parity with the Makefile name for the compressed provider-archives and bumps each provider a patch version in order for us to re-release the provider with the `aarch64-apple-darwin` target.

This PR, once released, also fixes #72 