### PR TITLE
Updated release actions to push to correct tag

### DIFF
--- a/.github/workflows/TEMPLATE_provider-release.yml
+++ b/.github/workflows/TEMPLATE_provider-release.yml
@@ -85,6 +85,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/fs-release.yml
+++ b/.github/workflows/fs-release.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/httpclient-release.yml
+++ b/.github/workflows/httpclient-release.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/httpserver-release.yml
+++ b/.github/workflows/httpserver-release.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/logging-release.yml
+++ b/.github/workflows/logging-release.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/nats-release.yml
+++ b/.github/workflows/nats-release.yml
@@ -91,6 +91,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redis-release.yml
+++ b/.github/workflows/redis-release.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redisgraph-release.yml
+++ b/.github/workflows/redisgraph-release.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/redisstreams-release.yml
+++ b/.github/workflows/redisstreams-release.yml
@@ -96,6 +96,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/s3-release.yml
+++ b/.github/workflows/s3-release.yml
@@ -89,6 +89,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/telnet-release.yml
+++ b/.github/workflows/telnet-release.yml
@@ -84,6 +84,7 @@ jobs:
         run: |
           VERSION=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')
           NAME=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name')
-          URL=${{secrets.AZURECR_PUSH_URL}}/$NAME:$VERSION
+          TAGNAME=$(echo $NAME | sed 's/wasmcloud-//')
+          URL=${{secrets.AZURECR_PUSH_URL}}/$TAGNAME:$VERSION
           wash reg push $URL $NAME.par.gz
         working-directory: ${{ env.working-directory }}

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ MIPS-based architectures are not cross-compiled by default because some capabili
 | Logging | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-logging)](https://crates.io/crates/wasmcloud-logging) | wasmcloud.azurecr.io/logging |
 | NATS | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-nats)](https://crates.io/crates/wasmcloud-nats) | wasmcloud.azurecr.io/nats |
 | Redis | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-redis)](https://crates.io/crates/wasmcloud-redis) | wasmcloud.azurecr.io/redis |
-| Redis Streams | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-redisstreams)](https://crates.io/crates/wasmcloud-redisstreams) | wasmcloud.azurecr.io/redisstreams |
+| Redis Streams | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-streams-redis)](https://crates.io/crates/wasmcloud-streams-redis) | wasmcloud.azurecr.io/streams-redis |
 | RedisGraph | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-redisgraph)](https://crates.io/crates/wasmcloud-redisgraph) | wasmcloud.azurecr.io/redisgraph |
 | S3 | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-s3)](https://crates.io/crates/wasmcloud-s3) | wasmcloud.azurecr.io/s3 |
 | Telnet | [![Crates.io](https://img.shields.io/crates/v/wasmcloud-telnet)](https://crates.io/crates/wasmcloud-telnet) | wasmcloud.azurecr.io/telnet |


### PR DESCRIPTION
Fixes #76 

This turned out to be a release action issue, rather than Makefiles. Now, instead of sourcing the tag solely from the crate name, we will remove the `wasmcloud-` suffix.