### PR TITLE
bump httpserver for CORS Support

### DIFF
--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-httpserver"
-version = "0.12.2"
+version = "0.12.3"
 authors = ["wasmCloud Team"]
 edition = "2018"
 homepage = "https://wasmcloud.dev"


### PR DESCRIPTION
Thank you @matthewtgilbride for the PR #74 to introduce CORS support, this is just a PR that bumps the httpserver a patch version, as the configuration values are optional and don't change the current behavior.