### PR TITLE
Updated actix_web for http-server

### DIFF
--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -26,7 +26,7 @@ rmp-serde = "0.15.4"
 serde_bytes = "0.11.5"
 serde = { version = "1.0.124", features = ["derive"] }
 actix-cors = "0.5.4"
-actix-web = "3.3.2"
+actix-web = "4.0.0-beta.8"
 actix-rt = "2.1.0"
 env_logger = "0.8.3"
 log = "0.4.14"

--- a/http-server/Cargo.toml
+++ b/http-server/Cargo.toml
@@ -25,7 +25,7 @@ crate-type = ["cdylib", "rlib"]
 rmp-serde = "0.15.4"
 serde_bytes = "0.11.5"
 serde = { version = "1.0.124", features = ["derive"] }
-actix-cors = "0.5.4"
+actix-cors = "0.6.0-beta.2"
 actix-web = "4.0.0-beta.8"
 actix-rt = "2.1.0"
 env_logger = "0.8.3"

--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -2,7 +2,7 @@ use actix_cors::Cors;
 use actix_rt;
 use actix_web::dev::Body;
 use actix_web::http::{HeaderName, HeaderValue, StatusCode};
-use actix_web::web::Bytes;
+use actix_web::web::{Bytes, Data};
 use actix_web::{middleware, web, App, HttpRequest, HttpResponse, HttpServer};
 use codec::capabilities::{CapabilityProvider, Dispatcher, NullDispatcher};
 use codec::core::{OP_BIND_ACTOR, OP_HEALTH_REQUEST, OP_REMOVE_ACTOR};
@@ -172,8 +172,8 @@ impl HttpServerProvider {
                 App::new()
                     .wrap(cors)
                     .wrap(middleware::Logger::default())
-                    .app_data(disp.clone())
-                    .app_data(module.clone())
+                    .app_data(Data::new(disp.clone()))
+                    .app_data(Data::new(module.clone()))
                     .default_service(web::route().to(request_handler))
             })
             .disable_signals();

--- a/http-server/src/lib.rs
+++ b/http-server/src/lib.rs
@@ -170,10 +170,10 @@ impl HttpServerProvider {
                 };
 
                 App::new()
-                    .wrap(middleware::Logger::default())
                     .wrap(cors)
-                    .data(disp.clone())
-                    .data(module.clone())
+                    .wrap(middleware::Logger::default())
+                    .app_data(disp.clone())
+                    .app_data(module.clone())
                     .default_service(web::route().to(request_handler))
             })
             .disable_signals();


### PR DESCRIPTION
When trying to run httpserver 0.12.2 on an M1 mac it crashes due to the use of actix_rt 2.x with actix_web 3.x. 