### PR TITLE
fix: timeout and rpc-timeout changed to ms

### DIFF
--- a/build/makefiles/provider.mk
+++ b/build/makefiles/provider.mk
@@ -154,7 +154,7 @@ start:
 	$(WASH) ctl start provider $(oci_url) \
 		--host-id $(shell $(WASH) ctl get hosts -o json | jq -r ".hosts[0].id") \
 		--link-name $(link_name) \
-		--timeout 4
+		--timeout-ms 4000
 
 # inspect claims on par file
 inspect: $(dest_par)


### PR DESCRIPTION
Related to a naming convention change a week ago:
wasmCloud/wash#198

Signed-off-by: Bailey Hayes <bhayes@singlestore.com>