### PR TITLE
wasmbus_rpc 0.6.0 bumps

### DIFF
--- a/httpclient/Cargo.lock
+++ b/httpclient/Cargo.lock
@@ -1215,7 +1215,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ec902eedf729792bd1ebe43e757691f956165c6db429deb26640925054de9"
 dependencies = [
  "half",
- "minicbor-derive",
+ "minicbor-derive 0.7.1",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65793a7836177614428b01e00d7089af2f308e8ad2fae92f324b2ee3c5d3bd9"
+dependencies = [
+ "half",
+ "minicbor-derive 0.8.0",
 ]
 
 [[package]]
@@ -1223,6 +1233,17 @@ name = "minicbor-derive"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355264ec26c23aae1d8d4599356cbd7e84134182b8feb9573acbd6d68c09c73e"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f79d5d3fb4f93c77ef7b97065fb65efe6abe670795ad8bc5be9c0e12005290"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -1311,6 +1332,37 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
+ "webpki",
+ "winapi",
+]
+
+[[package]]
+name = "nats"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d777a1844c3c5f4148df755a978fd99bb27c898d9bf016de723cf3ffcea5f5d"
+dependencies = [
+ "base64",
+ "base64-url",
+ "blocking",
+ "chrono",
+ "crossbeam-channel",
+ "fastrand",
+ "itoa",
+ "json",
+ "libc",
+ "log",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "url",
  "webpki",
  "winapi",
 ]
@@ -2804,8 +2856,42 @@ dependencies = [
  "data-encoding",
  "futures 0.3.17",
  "log",
- "minicbor",
- "nats",
+ "minicbor 0.11.4",
+ "nats 0.13.1",
+ "once_cell",
+ "pin-utils",
+ "ratsio_fork_040",
+ "ring",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-timer",
+ "toml",
+ "uuid",
+ "wascap",
+ "wasmbus-macros",
+ "weld-codegen",
+]
+
+[[package]]
+name = "wasmbus-rpc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408aa0284ccf21dceee06ee2dff52ac4260aa492995f83ad597b8df712cd8ba5"
+dependencies = [
+ "async-trait",
+ "base64",
+ "cfg-if 1.0.0",
+ "chrono",
+ "crossbeam",
+ "data-encoding",
+ "futures 0.3.17",
+ "log",
+ "minicbor 0.12.0",
+ "nats 0.16.0",
  "once_cell",
  "pin-utils",
  "ratsio_fork_040",
@@ -2826,16 +2912,16 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-httpclient"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ce765030134592fccff9f7a21f1859ebaf2d83dddf4ee0f7492f9605140ccab"
+checksum = "b134dc9066533ffdfeb09d807b6853ee40f7c48a3294542e8db788f4c8bd2399"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "weld-codegen",
 ]
 
@@ -2850,7 +2936,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.3",
  "weld-codegen",
 ]
 
@@ -2874,7 +2960,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "wasmcloud-interface-httpclient",
  "wasmcloud-test-util",
 ]
@@ -2897,7 +2983,7 @@ dependencies = [
  "tokio",
  "toml",
  "wascap",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.3",
  "wasmcloud-interface-testing",
 ]
 
@@ -2939,7 +3025,7 @@ dependencies = [
  "handlebars",
  "lazy_static",
  "lexical-sort",
- "minicbor",
+ "minicbor 0.11.4",
  "reqwest",
  "rustc-hash",
  "serde",

--- a/httpclient/Cargo.toml
+++ b/httpclient/Cargo.toml
@@ -20,12 +20,12 @@ serde = {version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 toml = "0.5"
-wasmcloud-interface-httpclient = "0.2.0"
-wasmbus-rpc = "0.5.2"
+wasmcloud-interface-httpclient = "0.3"
+wasmbus-rpc = "0.6"
 
 # test dependencies
 [dev-dependencies]
-wasmcloud-test-util = "0.1.8"
+wasmcloud-test-util = "0.2.1"
 
 [[bin]]
 name = "httpclient"

--- a/httpclient/Cargo.toml
+++ b/httpclient/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-httpclient"
-version = "0.3.5"
+version = "0.3.6"
 edition = "2021"
 
 [dependencies]

--- a/httpserver-rs/Cargo.lock
+++ b/httpserver-rs/Cargo.lock
@@ -1296,7 +1296,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ec902eedf729792bd1ebe43e757691f956165c6db429deb26640925054de9"
 dependencies = [
  "half",
- "minicbor-derive",
+ "minicbor-derive 0.7.1",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65793a7836177614428b01e00d7089af2f308e8ad2fae92f324b2ee3c5d3bd9"
+dependencies = [
+ "half",
+ "minicbor-derive 0.8.0",
 ]
 
 [[package]]
@@ -1304,6 +1314,17 @@ name = "minicbor-derive"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355264ec26c23aae1d8d4599356cbd7e84134182b8feb9573acbd6d68c09c73e"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f79d5d3fb4f93c77ef7b97065fb65efe6abe670795ad8bc5be9c0e12005290"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -1410,6 +1431,37 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
+ "webpki",
+ "winapi",
+]
+
+[[package]]
+name = "nats"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d777a1844c3c5f4148df755a978fd99bb27c898d9bf016de723cf3ffcea5f5d"
+dependencies = [
+ "base64",
+ "base64-url",
+ "blocking",
+ "chrono",
+ "crossbeam-channel",
+ "fastrand",
+ "itoa",
+ "json",
+ "libc",
+ "log",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "url",
  "webpki",
  "winapi",
 ]
@@ -3037,8 +3089,42 @@ dependencies = [
  "data-encoding",
  "futures 0.3.17",
  "log",
- "minicbor",
- "nats",
+ "minicbor 0.11.4",
+ "nats 0.13.1",
+ "once_cell",
+ "pin-utils",
+ "ratsio_fork_040",
+ "ring",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-timer",
+ "toml",
+ "uuid",
+ "wascap",
+ "wasmbus-macros",
+ "weld-codegen",
+]
+
+[[package]]
+name = "wasmbus-rpc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408aa0284ccf21dceee06ee2dff52ac4260aa492995f83ad597b8df712cd8ba5"
+dependencies = [
+ "async-trait",
+ "base64",
+ "cfg-if 1.0.0",
+ "chrono",
+ "crossbeam",
+ "data-encoding",
+ "futures 0.3.17",
+ "log",
+ "minicbor 0.12.0",
+ "nats 0.16.0",
  "once_cell",
  "pin-utils",
  "ratsio_fork_040",
@@ -3059,15 +3145,15 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-httpserver"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09cde70347ba62aa804f2704e4220437be0a73326b95e97cce2b7d90a53ac0f3"
+checksum = "e6fc65fc93bae0fde5f3c0961989438c80fa1fd42726e95215944844116c5bce"
 dependencies = [
  "async-trait",
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "weld-codegen",
 ]
 
@@ -3082,7 +3168,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.3",
  "weld-codegen",
 ]
 
@@ -3110,7 +3196,7 @@ dependencies = [
  "tokio",
  "toml",
  "warp",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "wasmcloud-interface-httpserver",
  "wasmcloud-test-util",
 ]
@@ -3133,7 +3219,7 @@ dependencies = [
  "tokio",
  "toml",
  "wascap",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.3",
  "wasmcloud-interface-testing",
 ]
 
@@ -3175,7 +3261,7 @@ dependencies = [
  "handlebars",
  "lazy_static",
  "lexical-sort",
- "minicbor",
+ "minicbor 0.11.4",
  "reqwest",
  "rustc-hash",
  "serde",

--- a/httpserver-rs/Cargo.toml
+++ b/httpserver-rs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-httpserver"
-version = "0.14.6"
+version = "0.14.7"
 edition = "2021"
 
 [dependencies]

--- a/httpserver-rs/Cargo.toml
+++ b/httpserver-rs/Cargo.toml
@@ -21,14 +21,14 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 toml = "0.5"
 warp = {version="0.3", features=["tls"]}
-wasmcloud-interface-httpserver = "0.2.0"
-wasmbus-rpc = "0.5.2"
+wasmcloud-interface-httpserver = "0.3"
+wasmbus-rpc = "0.6"
 
 [dev-dependencies]
 assert_matches = "1.5"
 blake2 = "0.9"
 reqwest = { version = "0.11", features = ["json"]}
-wasmcloud-test-util = "0.1.8"
+wasmcloud-test-util = "0.2.1"
 
 [lib]
 name = "wasmcloud_provider_httpserver"

--- a/kvredis/Cargo.lock
+++ b/kvredis/Cargo.lock
@@ -1235,7 +1235,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ec902eedf729792bd1ebe43e757691f956165c6db429deb26640925054de9"
 dependencies = [
  "half",
- "minicbor-derive",
+ "minicbor-derive 0.7.1",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65793a7836177614428b01e00d7089af2f308e8ad2fae92f324b2ee3c5d3bd9"
+dependencies = [
+ "half",
+ "minicbor-derive 0.8.0",
 ]
 
 [[package]]
@@ -1243,6 +1253,17 @@ name = "minicbor-derive"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355264ec26c23aae1d8d4599356cbd7e84134182b8feb9573acbd6d68c09c73e"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f79d5d3fb4f93c77ef7b97065fb65efe6abe670795ad8bc5be9c0e12005290"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -1331,6 +1352,37 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
+ "webpki",
+ "winapi",
+]
+
+[[package]]
+name = "nats"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d777a1844c3c5f4148df755a978fd99bb27c898d9bf016de723cf3ffcea5f5d"
+dependencies = [
+ "base64",
+ "base64-url",
+ "blocking",
+ "chrono",
+ "crossbeam-channel",
+ "fastrand",
+ "itoa",
+ "json",
+ "libc",
+ "log",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "url",
  "webpki",
  "winapi",
 ]
@@ -2850,8 +2902,42 @@ dependencies = [
  "data-encoding",
  "futures 0.3.17",
  "log",
- "minicbor",
- "nats",
+ "minicbor 0.11.4",
+ "nats 0.13.1",
+ "once_cell",
+ "pin-utils",
+ "ratsio_fork_040",
+ "ring",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-timer",
+ "toml",
+ "uuid",
+ "wascap",
+ "wasmbus-macros",
+ "weld-codegen",
+]
+
+[[package]]
+name = "wasmbus-rpc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408aa0284ccf21dceee06ee2dff52ac4260aa492995f83ad597b8df712cd8ba5"
+dependencies = [
+ "async-trait",
+ "base64",
+ "cfg-if 1.0.0",
+ "chrono",
+ "crossbeam",
+ "data-encoding",
+ "futures 0.3.17",
+ "log",
+ "minicbor 0.12.0",
+ "nats 0.16.0",
  "once_cell",
  "pin-utils",
  "ratsio_fork_040",
@@ -2872,16 +2958,16 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-keyvalue"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786f9ff29ec10628624a8363e57b8b52e44c1d0900fb41415cb0465bf7c23aa5"
+checksum = "4017afbf25cd670646ddaadccdb062163e233d82554ffa4510eb4303850828b6"
 dependencies = [
  "async-trait",
  "log",
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "weld-codegen",
 ]
 
@@ -2896,7 +2982,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.3",
  "weld-codegen",
 ]
 
@@ -2921,7 +3007,7 @@ dependencies = [
  "thiserror",
  "tokio",
  "toml",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "wasmcloud-interface-keyvalue",
  "wasmcloud-test-util",
 ]
@@ -2944,7 +3030,7 @@ dependencies = [
  "tokio",
  "toml",
  "wascap",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.3",
  "wasmcloud-interface-testing",
 ]
 
@@ -2986,7 +3072,7 @@ dependencies = [
  "handlebars",
  "lazy_static",
  "lexical-sort",
- "minicbor",
+ "minicbor 0.11.4",
  "reqwest",
  "rustc-hash",
  "serde",

--- a/kvredis/Cargo.toml
+++ b/kvredis/Cargo.toml
@@ -20,12 +20,12 @@ serde = {version = "1.0", features = ["derive"] }
 thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 toml = "0.5"
-wasmcloud-interface-keyvalue = "0.3.0"
-wasmbus-rpc = "0.5.2"
+wasmcloud-interface-keyvalue = "0.4"
+wasmbus-rpc = "0.6"
 
 # test dependencies
 [dev-dependencies]
-wasmcloud-test-util = "0.1.8"
+wasmcloud-test-util = "0.2.1"
 rand = "0.8"
 
 [[bin]]

--- a/kvredis/Cargo.toml
+++ b/kvredis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-kvredis"
-version = "0.14.5"
+version = "0.14.6"
 edition = "2021"
 
 [dependencies]

--- a/lattice-controller/Cargo.toml
+++ b/lattice-controller/Cargo.toml
@@ -22,12 +22,12 @@ tokio = { version = "1", features = ["full"] }
 toml = "0.5"
 wasmbus-rpc = "0.6.0"
 wascap = "0.6.1"
-wasmcloud-interface-lattice-control = "0.3.1"
+wasmcloud-interface-lattice-control = "0.3"
 wasmcloud-control-interface = "0.7.1"
 nats = "0.16"
 # test dependencies
 [dev-dependencies]
-wasmcloud-test-util = "0.1.9"
+wasmcloud-test-util = "0.2.1"
 
 
 

--- a/nats/Cargo.lock
+++ b/nats/Cargo.lock
@@ -1215,7 +1215,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ec902eedf729792bd1ebe43e757691f956165c6db429deb26640925054de9"
 dependencies = [
  "half",
- "minicbor-derive",
+ "minicbor-derive 0.7.1",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65793a7836177614428b01e00d7089af2f308e8ad2fae92f324b2ee3c5d3bd9"
+dependencies = [
+ "half",
+ "minicbor-derive 0.8.0",
 ]
 
 [[package]]
@@ -1223,6 +1233,17 @@ name = "minicbor-derive"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355264ec26c23aae1d8d4599356cbd7e84134182b8feb9573acbd6d68c09c73e"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f79d5d3fb4f93c77ef7b97065fb65efe6abe670795ad8bc5be9c0e12005290"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -1311,6 +1332,37 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
+ "webpki",
+ "winapi",
+]
+
+[[package]]
+name = "nats"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d777a1844c3c5f4148df755a978fd99bb27c898d9bf016de723cf3ffcea5f5d"
+dependencies = [
+ "base64",
+ "base64-url",
+ "blocking",
+ "chrono",
+ "crossbeam-channel",
+ "fastrand",
+ "itoa",
+ "json",
+ "libc",
+ "log",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "url",
  "webpki",
  "winapi",
 ]
@@ -2804,8 +2856,42 @@ dependencies = [
  "data-encoding",
  "futures 0.3.17",
  "log",
- "minicbor",
- "nats",
+ "minicbor 0.11.4",
+ "nats 0.13.1",
+ "once_cell",
+ "pin-utils",
+ "ratsio_fork_040",
+ "ring",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-timer",
+ "toml",
+ "uuid",
+ "wascap",
+ "wasmbus-macros",
+ "weld-codegen",
+]
+
+[[package]]
+name = "wasmbus-rpc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408aa0284ccf21dceee06ee2dff52ac4260aa492995f83ad597b8df712cd8ba5"
+dependencies = [
+ "async-trait",
+ "base64",
+ "cfg-if 1.0.0",
+ "chrono",
+ "crossbeam",
+ "data-encoding",
+ "futures 0.3.17",
+ "log",
+ "minicbor 0.12.0",
+ "nats 0.16.0",
  "once_cell",
  "pin-utils",
  "ratsio_fork_040",
@@ -2826,16 +2912,16 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-messaging"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "868185b48a0345b061bafad33d4e06da44e8a43b79e09fc4112b0fd545d1e46f"
+checksum = "e339f373c48260353e823312b05dacfdaa536263baff125f5854bbe53fc39a35"
 dependencies = [
  "async-trait",
  "log",
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "weld-codegen",
 ]
 
@@ -2850,7 +2936,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.3",
  "weld-codegen",
 ]
 
@@ -2865,7 +2951,7 @@ dependencies = [
  "crossbeam",
  "futures 0.3.17",
  "log",
- "nats",
+ "nats 0.13.1",
  "once_cell",
  "rmp-serde",
  "serde",
@@ -2875,7 +2961,7 @@ dependencies = [
  "tokio",
  "toml",
  "wascap",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "wasmcloud-interface-messaging",
  "wasmcloud-test-util",
 ]
@@ -2898,7 +2984,7 @@ dependencies = [
  "tokio",
  "toml",
  "wascap",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.3",
  "wasmcloud-interface-testing",
 ]
 
@@ -2940,7 +3026,7 @@ dependencies = [
  "handlebars",
  "lazy_static",
  "lexical-sort",
- "minicbor",
+ "minicbor 0.11.4",
  "reqwest",
  "rustc-hash",
  "serde",

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -21,12 +21,12 @@ thiserror = "1.0"
 tokio = { version = "1", features = ["full"] }
 toml = "0.5"
 wascap = "0.6"
-wasmbus-rpc = "0.5.2"
-wasmcloud-interface-messaging = "0.2.0"
+wasmbus-rpc = "0.6"
+wasmcloud-interface-messaging = "0.3"
 
 # test dependencies
 [dev-dependencies]
-wasmcloud-test-util = "0.1.8"
+wasmcloud-test-util = "0.2.1"
 
 [[bin]]
 name = "nats_messaging"

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-nats"
-version = "0.11.5"
+version = "0.11.6"
 edition = "2021"
 
 [dependencies]

--- a/sqldb-postgres/Cargo.lock
+++ b/sqldb-postgres/Cargo.lock
@@ -1292,7 +1292,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d6ec902eedf729792bd1ebe43e757691f956165c6db429deb26640925054de9"
 dependencies = [
  "half",
- "minicbor-derive",
+ "minicbor-derive 0.7.1",
+]
+
+[[package]]
+name = "minicbor"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e65793a7836177614428b01e00d7089af2f308e8ad2fae92f324b2ee3c5d3bd9"
+dependencies = [
+ "half",
+ "minicbor-derive 0.8.0",
 ]
 
 [[package]]
@@ -1300,6 +1310,17 @@ name = "minicbor-derive"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "355264ec26c23aae1d8d4599356cbd7e84134182b8feb9573acbd6d68c09c73e"
+dependencies = [
+ "proc-macro2 1.0.32",
+ "quote 1.0.10",
+ "syn 1.0.81",
+]
+
+[[package]]
+name = "minicbor-derive"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f79d5d3fb4f93c77ef7b97065fb65efe6abe670795ad8bc5be9c0e12005290"
 dependencies = [
  "proc-macro2 1.0.32",
  "quote 1.0.10",
@@ -1388,6 +1409,37 @@ dependencies = [
  "rustls-native-certs",
  "serde",
  "serde_json",
+ "webpki",
+ "winapi",
+]
+
+[[package]]
+name = "nats"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d777a1844c3c5f4148df755a978fd99bb27c898d9bf016de723cf3ffcea5f5d"
+dependencies = [
+ "base64",
+ "base64-url",
+ "blocking",
+ "chrono",
+ "crossbeam-channel",
+ "fastrand",
+ "itoa",
+ "json",
+ "libc",
+ "log",
+ "memchr",
+ "nkeys",
+ "nuid",
+ "once_cell",
+ "parking_lot",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "serde_json",
+ "url",
  "webpki",
  "winapi",
 ]
@@ -2977,8 +3029,42 @@ dependencies = [
  "data-encoding",
  "futures 0.3.17",
  "log",
- "minicbor",
- "nats",
+ "minicbor 0.11.4",
+ "nats 0.13.1",
+ "once_cell",
+ "pin-utils",
+ "ratsio_fork_040",
+ "ring",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror",
+ "tokio",
+ "tokio-timer",
+ "toml",
+ "uuid",
+ "wascap",
+ "wasmbus-macros",
+ "weld-codegen",
+]
+
+[[package]]
+name = "wasmbus-rpc"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "408aa0284ccf21dceee06ee2dff52ac4260aa492995f83ad597b8df712cd8ba5"
+dependencies = [
+ "async-trait",
+ "base64",
+ "cfg-if 1.0.0",
+ "chrono",
+ "crossbeam",
+ "data-encoding",
+ "futures 0.3.17",
+ "log",
+ "minicbor 0.12.0",
+ "nats 0.16.0",
  "once_cell",
  "pin-utils",
  "ratsio_fork_040",
@@ -2999,17 +3085,17 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-interface-sqldb"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fc4740cb22c411aa63b7a90e6e2d49e90ee13b4bcd39254ca04cc95fec7f240"
+checksum = "dbae0122e06239cf45040fe72e02e1c328ad9585084d48263398dbe8f8934603"
 dependencies = [
  "async-trait",
  "futures 0.3.17",
- "minicbor",
+ "minicbor 0.11.4",
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "weld-codegen",
 ]
 
@@ -3024,7 +3110,7 @@ dependencies = [
  "serde",
  "serde_bytes",
  "serde_json",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.2",
  "weld-codegen",
 ]
 
@@ -3041,7 +3127,7 @@ dependencies = [
  "crossbeam",
  "futures 0.3.17",
  "log",
- "minicbor",
+ "minicbor 0.11.4",
  "native-tls",
  "once_cell",
  "rmp-serde",
@@ -3053,7 +3139,7 @@ dependencies = [
  "tokio-postgres",
  "toml",
  "uuid",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.6.0",
  "wasmcloud-interface-sqldb",
  "wasmcloud-test-util",
 ]
@@ -3076,7 +3162,7 @@ dependencies = [
  "tokio",
  "toml",
  "wascap",
- "wasmbus-rpc",
+ "wasmbus-rpc 0.5.2",
  "wasmcloud-interface-testing",
 ]
 
@@ -3118,7 +3204,7 @@ dependencies = [
  "handlebars",
  "lazy_static",
  "lexical-sort",
- "minicbor",
+ "minicbor 0.11.4",
  "reqwest",
  "rustc-hash",
  "serde",

--- a/sqldb-postgres/Cargo.toml
+++ b/sqldb-postgres/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-sqldb-postgres"
-version = "0.1.1"
+version = "0.1.2"
 description = "Postgres SQL Database capability provider for contract wasmcloud:sqldb"
 readme = "README.md"
 edition = "2021"

--- a/sqldb-postgres/Cargo.toml
+++ b/sqldb-postgres/Cargo.toml
@@ -28,12 +28,12 @@ uuid = "0.8"
 #postgres-native-tls = "0.5"
 native-tls = "0.2"
 toml = "0.5"
-wasmcloud-interface-sqldb = "0.2.0"
-wasmbus-rpc = "0.5.2"
+wasmcloud-interface-sqldb = "0.3"
+wasmbus-rpc = "0.6"
 
 # test dependencies
 [dev-dependencies]
-wasmcloud-test-util = "0.1.8"
+wasmcloud-test-util = "0.2.1"
 
 [[bin]]
 name = "sqldb-postgres"


### PR DESCRIPTION
This PR bumps `wasmbus_rpc` to version `0.6` across all providers, as well as their corresponding interfaces to compatible versions.

Because this only affected underlying dependencies and introduced no new features or interactions with these providers, all providers will get a patch bump for release.