### PR TITLE
Run capability provider builds in parallel

### DIFF
--- a/.github/workflows/TEMPLATE_provider.yml
+++ b/.github/workflows/TEMPLATE_provider.yml
@@ -4,15 +4,15 @@ name: PROVIDER
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "provider/**"
+      - "provider/**"
     tags:
-    - 'provider-v*'
+      - "provider-v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "provider/**"
+      - "provider/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -24,59 +24,130 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    # If your integration tests require nats or redis, run them here
-    - id: rust-check-action
-      uses: wasmcloud/common-actions/rust-check@main
-      with:
-        working-directory: ${{ env.working-directory }}
+      - uses: actions/checkout@v2
+      # If your integration tests require nats or redis, run them here
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
+
+  install_cross:
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Upload cross binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin/cross
 
   build_artifact:
-    needs: rust_check
+    needs: install_cross
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download cross binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin
+
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+        working-directory: ${{ env.working-directory }}
+
+      - name: Build native executable
+        run: |
+          chmod +x ~/.cargo/bin/cross
+          cross build --release --target ${{ matrix.target }}
+        working-directory: ${{ env.working-directory }}
+
+      - name: Upload executable to GH Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_artifact]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: wasmcloud/common-actions/install-wash@main
-      - uses: wasmcloud/common-actions/install-cross@main
+      # Downloads all artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: ${{ env.working-directory }}
 
-      - name: Build full provider archive
-        run: make par-full
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
-      
+
+      - name: Create provider archive
+        working-directory: ${{ env.working-directory }}
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make par
+
+      - name: Insert provider archive targets
+        working-directory: ${{ env.working-directory }}
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+
       - name: Upload provider archive to GH Actions
         uses: actions/upload-artifact@v2
         with:
           name: provider-archive
-          path: ${{ env.working-directory }}/build/*.par.gz
+          path: ${{ env.working-directory }}/build/${{ env.artifact-name }}.par.gz
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
-    - name: Download provider archive
-      uses: actions/download-artifact@v2
-      with:
-        name: provider-archive
-        path: ${{ env.working-directory }}/build
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/build/*.par.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.working-directory }}/build/*.par.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   artifact_release:
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -19,19 +19,19 @@ env:
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_HTTPCLIENT }}
 
 jobs:
-  rust_check:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - id: run-nats
-        uses: wasmcloud/common-actions/run-nats@main
-      - id: rust-check-action
-        uses: wasmcloud/common-actions/rust-check@main
-        with:
-          working-directory: ${{ env.working-directory }}
+  # rust_check:
+  #   runs-on: ubuntu-latest
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #     - id: run-nats
+  #       uses: wasmcloud/common-actions/run-nats@main
+  #     - id: rust-check-action
+  #       uses: wasmcloud/common-actions/rust-check@main
+  #       with:
+  #         working-directory: ${{ env.working-directory }}
 
   build_artifact:
-    needs: rust_check
+    # needs: rust_check
     # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}
-          # if-no-files-found: error
+          if-no-files-found: error
           path: |
             ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
             ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -9,8 +9,8 @@ on:
       - "httpclient-v*"
   pull_request:
     branches: [main]
-    # paths:
-    # - "httpclient/**"
+    paths:
+      - "httpclient/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -19,19 +19,19 @@ env:
   WASH_SUBJECT_KEY: ${{ secrets.WASMCLOUD_HTTPCLIENT }}
 
 jobs:
-  # rust_check:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - id: run-nats
-  #       uses: wasmcloud/common-actions/run-nats@main
-  #     - id: rust-check-action
-  #       uses: wasmcloud/common-actions/rust-check@main
-  #       with:
-  #         working-directory: ${{ env.working-directory }}
+  rust_check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
 
   install_cross:
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: wasmcloud/common-actions/install-cross@main
@@ -42,8 +42,8 @@ jobs:
           path: ~/.cargo/bin/cross
 
   build_artifact:
-    # needs: [rust_check, install_cross]
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: [rust_check, install_cross]
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
         target:
@@ -56,7 +56,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Download cross binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin
 
       - name: Determine artifact name
         run: |
@@ -64,7 +68,9 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: Build native executable
-        run: cross build --release --target ${{ matrix.target }}
+        run: |
+          chmod +x ~/.cargo/bin/cross
+          cross build --release --target ${{ matrix.target }}
         working-directory: ${{ env.working-directory }}
 
       - name: Upload executable to GH Actions
@@ -81,18 +87,42 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-
+      - uses: wasmcloud/common-actions/install-wash@main
+      # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:
-          path: path/to/artifacts
+          path: ${{ env.working-directory }}
 
-      - name: Display structure of downloaded files
-        run: ls -R
-        working-directory: path/to/artifacts
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+        working-directory: ${{ env.working-directory }}
+
+      - name: Create provider archive
+        working-directory: ${{ env.working-directory }}
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make build/${{ env.artifact-name }}.par.gz
+
+      - name: Insert provider archive targets
+        working-directory: ${{ env.working-directory }}
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+
+      - name: Upload provider archive to GH Actions
+        uses: actions/upload-artifact@v2
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build/${{ env.artifact-name }}.par.gz
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: build_artifact
+    needs: assemble_provider_archive
     runs-on: ubuntu-latest
     steps:
       - name: Download provider archive
@@ -110,7 +140,7 @@ jobs:
           draft: false
 
   artifact_release:
-    needs: build_artifact
+    needs: assemble_provider_archive
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -9,8 +9,8 @@ on:
       - "httpclient-v*"
   pull_request:
     branches: [main]
-    paths:
-      - "httpclient/**"
+    # paths:
+    #   - "httpclient/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -42,7 +42,7 @@ jobs:
           path: ~/.cargo/bin/cross
 
   build_artifact:
-    needs: [rust_check, install_cross]
+    needs: install_cross
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
@@ -122,7 +122,7 @@ jobs:
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: assemble_provider_archive
+    needs: [rust_check, assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
       - name: Download provider archive
@@ -140,7 +140,7 @@ jobs:
           draft: false
 
   artifact_release:
-    needs: assemble_provider_archive
+    needs: [rust_check, assemble_provider_archive]
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -2,15 +2,15 @@ name: HTTPCLIENT
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "httpclient/**"
+      - "httpclient/**"
     tags:
-    - 'httpclient-v*'
+      - "httpclient-v*"
   pull_request:
-    branches: [ main ]
-    paths:
-    - "httpclient/**"
+    branches: [main]
+    # paths:
+    # - "httpclient/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,51 +22,64 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: run-nats
-      uses: wasmcloud/common-actions/run-nats@main
-    - id: rust-check-action
-      uses: wasmcloud/common-actions/rust-check@main
-      with:
-        working-directory: ${{ env.working-directory }}
+      - uses: actions/checkout@v2
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
 
   build_artifact:
     needs: rust_check
-    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - uses: wasmcloud/common-actions/install-wash@main
       - uses: wasmcloud/common-actions/install-cross@main
 
-      - name: Build full provider archive
-        run: make par-full
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
-      
-      - name: Upload provider archive to GH Actions
+
+      - name: Build native executable
+        run: cross build --release --target ${{ matrix.target }}
+        working-directory: ${{ env.working-directory }}
+
+      - name: Upload executable to GH Actions
         uses: actions/upload-artifact@v2
         with:
-          name: provider-archive
-          path: ${{ env.working-directory }}/build/*.par.gz
+          name: ${{ matrix.target }}
+          path: ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     needs: build_artifact
     runs-on: ubuntu-latest
     steps:
-    - name: Download provider archive
-      uses: actions/download-artifact@v2
-      with:
-        name: provider-archive
-        path: ${{ env.working-directory }}/build
+      - name: Download provider archive
+        uses: actions/download-artifact@v2
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/build/*.par.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.working-directory }}/build/*.par.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   artifact_release:
     needs: build_artifact

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -103,7 +103,7 @@ jobs:
         run: |
           mkdir -p target/release
           mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
-          make build/${{ env.artifact-name }}.par.gz
+          make par
 
       - name: Insert provider archive targets
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -30,7 +30,19 @@ jobs:
   #       with:
   #         working-directory: ${{ env.working-directory }}
 
+  install_cross:
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Upload cross binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin/cross
+
   build_artifact:
+    # needs: [rust_check, install_cross]
     # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
@@ -56,17 +68,27 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: Upload executable to GH Actions
-        if: ${{ !contains(matrix.target, 'windows') }}
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.target }}
-          path: ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
-      - name: Upload executable to GH Actions (windows)
-        if: ${{ contains(matrix.target, 'windows') }}
-        uses: actions/upload-artifact@v2
+          # if-no-files-found: error
+          path: |
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_artifact]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions/download-artifact@v3
         with:
-          name: ${{ matrix.target }}
-          path: ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+          path: path/to/artifacts
+
+      - name: Display structure of downloaded files
+        run: ls -R
+        working-directory: path/to/artifacts
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
@@ -74,7 +96,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build
@@ -94,7 +116,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -31,7 +31,6 @@ jobs:
   #         working-directory: ${{ env.working-directory }}
 
   build_artifact:
-    # needs: rust_check
     # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
@@ -57,10 +56,17 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: Upload executable to GH Actions
+        if: ${{ !contains(matrix.target, 'windows') }}
         uses: actions/upload-artifact@v2
         with:
           name: ${{ matrix.target }}
           path: ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+      - name: Upload executable to GH Actions (windows)
+        if: ${{ contains(matrix.target, 'windows') }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ matrix.target }}
+          path: ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -9,8 +9,8 @@ on:
       - "httpclient-v*"
   pull_request:
     branches: [main]
-    # paths:
-    #   - "httpclient/**"
+    paths:
+      - "httpclient/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -9,8 +9,8 @@ on:
       - "httpserver-v*"
   pull_request:
     branches: [main]
-    paths:
-      - "httpserver-rs/**"
+    # paths:
+    #   - "httpserver-rs/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Determine artifact name
         run: |
-          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[1].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
 
       - name: Build native executable

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -2,15 +2,15 @@ name: HTTPSERVER
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "httpserver-rs/**"
+      - "httpserver-rs/**"
     tags:
-    - 'httpserver-v*'
+      - "httpserver-v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "httpserver-rs/**"
+      - "httpserver-rs/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,60 +22,131 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: run-nats
-      uses: wasmcloud/common-actions/run-nats@main
-    - id: rust-check-action
-      uses: wasmcloud/common-actions/rust-check@main
-      with:
-        working-directory: ${{ env.working-directory }}
+      - uses: actions/checkout@v2
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
+
+  install_cross:
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Upload cross binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin/cross
 
   build_artifact:
-    needs: rust_check
-    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: install_cross
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download cross binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin
+
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+        working-directory: ${{ env.working-directory }}
+
+      - name: Build native executable
+        run: |
+          chmod +x ~/.cargo/bin/cross
+          cross build --release --target ${{ matrix.target }}
+        working-directory: ${{ env.working-directory }}
+
+      - name: Upload executable to GH Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_artifact]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: wasmcloud/common-actions/install-wash@main
-      - uses: wasmcloud/common-actions/install-cross@main
+      # Downloads all artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: ${{ env.working-directory }}
 
-      - name: Build full provider archive
-        run: make par-full
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
-      
+
+      - name: Create provider archive
+        working-directory: ${{ env.working-directory }}
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make par
+
+      - name: Insert provider archive targets
+        working-directory: ${{ env.working-directory }}
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+
       - name: Upload provider archive to GH Actions
         uses: actions/upload-artifact@v2
         with:
           name: provider-archive
-          path: ${{ env.working-directory }}/build/*.par.gz
+          path: ${{ env.working-directory }}/build/${{ env.artifact-name }}.par.gz
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
-    - name: Download provider archive
-      uses: actions/download-artifact@v2
-      with:
-        name: provider-archive
-        path: ${{ env.working-directory }}/build
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/build/*.par.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.working-directory }}/build/*.par.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   artifact_release:
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -31,7 +31,7 @@ jobs:
           working-directory: ${{ env.working-directory }}
 
   install_cross:
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: wasmcloud/common-actions/install-cross@main
@@ -43,7 +43,7 @@ jobs:
 
   build_artifact:
     needs: install_cross
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
         target:

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Determine artifact name
         run: |
-          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[1].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
 
       - name: Create provider archive

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Determine artifact name
         run: |
-          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[1].name')" >> $GITHUB_ENV
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
 
       - name: Create provider archive

--- a/.github/workflows/kv-vault.yml
+++ b/.github/workflows/kv-vault.yml
@@ -92,7 +92,7 @@ jobs:
       - name: Build native executable
         run: |
           chmod +x ~/.cargo/bin/cross
-          cross build --release --target ${{ matrix.target }}
+          XDG_CACHE_HOME=${HOME}/.cache cross build --release --target ${{ matrix.target }}
         working-directory: ${{ env.working-directory }}
 
       - name: Upload executable to GH Actions

--- a/.github/workflows/kv-vault.yml
+++ b/.github/workflows/kv-vault.yml
@@ -9,8 +9,8 @@ on:
       - "kv-vault-v*"
   pull_request:
     branches: [main]
-    # paths:
-    #   - "kv-vault/**"
+    paths:
+      - "kv-vault/**"
   workflow_dispatch:
     inputs:
       release:
@@ -53,7 +53,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
   install_cross:
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: wasmcloud/common-actions/install-cross@main
@@ -65,7 +65,7 @@ jobs:
 
   build_artifact:
     needs: install_cross
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
         target:

--- a/.github/workflows/kv-vault.yml
+++ b/.github/workflows/kv-vault.yml
@@ -2,26 +2,25 @@ name: KV_VAULT
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "kv-vault/**"
+      - "kv-vault/**"
     tags:
-    - 'kv-vault-v*'
+      - "kv-vault-v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "kv-vault/**"
+      - "kv-vault/**"
   workflow_dispatch:
     inputs:
       release:
-        description: 'Build github release (enter y)'
-        default: 'n'
+        description: "Build github release (enter y)"
+        default: "n"
         required: true
       artifact:
-        description: 'Build github release and push artifact (enter y)'
-        default: 'n'
+        description: "Build github release and push artifact (enter y)"
+        default: "n"
         required: true
-
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,78 +33,149 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: rust-check-action
-      uses: wasmcloud/common-actions/rust-check@main
-      with:
-        working-directory: ${{ env.working-directory }}
-        # disable testing with "cargo test" since this will run 'make test'
-        test-options: --no-run
+      - uses: actions/checkout@v2
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
+          # disable testing with "cargo test" since this will run 'make test'
+          test-options: --no-run
 
   make_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: run-nats
-      uses: wasmcloud/common-actions/run-nats@main
-    - name: Run tests
-      run: ./run-test.sh
-      shell: bash
-      working-directory: ${{ env.working-directory }}
+      - uses: actions/checkout@v2
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - name: Run tests
+        run: ./run-test.sh
+        shell: bash
+        working-directory: ${{ env.working-directory }}
+
+  install_cross:
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Upload cross binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin/cross
 
   build_artifact:
-    needs: [ rust_check, make_test ]
-    # run on tag push or manual with 'y'
-    if: ${{ ( startswith(github.ref, 'refs/tags/') || github.events.inputs.artifact == 'y' || github.events.inputs.release == 'y' ) }}
+    needs: install_cross
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download cross binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin
+
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+        working-directory: ${{ env.working-directory }}
+
+      - name: Build native executable
+        run: |
+          chmod +x ~/.cargo/bin/cross
+          cross build --release --target ${{ matrix.target }}
+        working-directory: ${{ env.working-directory }}
+
+      - name: Upload executable to GH Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_artifact]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: wasmcloud/common-actions/install-wash@main
-      - uses: wasmcloud/common-actions/install-cross@main
+      # Downloads all artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: ${{ env.working-directory }}
 
-      - name: Build full provider archive
-        run: make par-full
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
-      
+
+      - name: Create provider archive
+        working-directory: ${{ env.working-directory }}
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make par
+
+      - name: Insert provider archive targets
+        working-directory: ${{ env.working-directory }}
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+
       - name: Upload provider archive to GH Actions
         uses: actions/upload-artifact@v2
         with:
           name: provider-archive
-          path: ${{ env.working-directory }}/build/*.par.gz
+          path: ${{ env.working-directory }}/build/${{ env.artifact-name }}.par.gz
 
   github_release:
-    if: ${{ ( startswith(github.ref, 'refs/tags/') || github.events.inputs.artifact == 'y' || github.events.inputs.release == 'y' ) }}
-    needs: build_artifact
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: [rust_check, assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
-    - name: Download provider archive
-      uses: actions/download-artifact@v2
-      with:
-        name: provider-archive
-        path: ${{ env.working-directory }}/build
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/build/*.par.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.working-directory }}/build/*.par.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   artifact_release:
-    needs: build_artifact
-    if: ${{ ( startswith(github.ref, 'refs/tags/') || github.events.inputs.artifact == 'y' ) }}
+    needs: [rust_check, assemble_provider_archive]
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build
 
       - name: Determine artifact metadata
         run: |
+          echo "oci-repository=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name' | sed 's/wasmcloud-provider-//')" >> $GITHUB_ENV
           echo "oci-version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
 

--- a/.github/workflows/kv-vault.yml
+++ b/.github/workflows/kv-vault.yml
@@ -91,6 +91,7 @@ jobs:
 
       - name: Build native executable
         run: |
+          mkdir -p ${HOME}/.cache
           chmod +x ~/.cargo/bin/cross
           XDG_CACHE_HOME=${HOME}/.cache cross build --release --target ${{ matrix.target }}
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/kv-vault.yml
+++ b/.github/workflows/kv-vault.yml
@@ -9,8 +9,8 @@ on:
       - "kv-vault-v*"
   pull_request:
     branches: [main]
-    paths:
-      - "kv-vault/**"
+    # paths:
+    #   - "kv-vault/**"
   workflow_dispatch:
     inputs:
       release:

--- a/.github/workflows/kvredis.yml
+++ b/.github/workflows/kvredis.yml
@@ -9,8 +9,8 @@ on:
       - "kvredis-v*"
   pull_request:
     branches: [main]
-    paths:
-      - "kvredis/**"
+    # paths:
+    #   - "kvredis/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/kvredis.yml
+++ b/.github/workflows/kvredis.yml
@@ -9,8 +9,8 @@ on:
       - "kvredis-v*"
   pull_request:
     branches: [main]
-    # paths:
-    #   - "kvredis/**"
+    paths:
+      - "kvredis/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,7 +34,7 @@ jobs:
           working-directory: ${{ env.working-directory }}
 
   install_cross:
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: wasmcloud/common-actions/install-cross@main
@@ -46,7 +46,7 @@ jobs:
 
   build_artifact:
     needs: install_cross
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
         target:

--- a/.github/workflows/kvredis.yml
+++ b/.github/workflows/kvredis.yml
@@ -2,15 +2,15 @@ name: KVREDIS
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "kvredis/**"
+      - "kvredis/**"
     tags:
-    - 'kvredis-v*'
+      - "kvredis-v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "kvredis/**"
+      - "kvredis/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,63 +22,134 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: run-nats
-      uses: wasmcloud/common-actions/run-nats@main
-    - id: run-redis
-      uses: wasmcloud/common-actions/run-redis@main
-    # If your integration tests require nats or redis, run them here
-    - id: rust-check-action
-      uses: wasmcloud/common-actions/rust-check@main
-      with:
-        working-directory: ${{ env.working-directory }}
+      - uses: actions/checkout@v2
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - id: run-redis
+        uses: wasmcloud/common-actions/run-redis@main
+      # If your integration tests require nats or redis, run them here
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
+
+  install_cross:
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Upload cross binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin/cross
 
   build_artifact:
-    needs: rust_check
-    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: install_cross
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download cross binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin
+
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+        working-directory: ${{ env.working-directory }}
+
+      - name: Build native executable
+        run: |
+          chmod +x ~/.cargo/bin/cross
+          cross build --release --target ${{ matrix.target }}
+        working-directory: ${{ env.working-directory }}
+
+      - name: Upload executable to GH Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_artifact]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: wasmcloud/common-actions/install-wash@main
-      - uses: wasmcloud/common-actions/install-cross@main
+      # Downloads all artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: ${{ env.working-directory }}
 
-      - name: Build full provider archive
-        run: make par-full
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
-      
+
+      - name: Create provider archive
+        working-directory: ${{ env.working-directory }}
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make par
+
+      - name: Insert provider archive targets
+        working-directory: ${{ env.working-directory }}
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+
       - name: Upload provider archive to GH Actions
         uses: actions/upload-artifact@v2
         with:
           name: provider-archive
-          path: ${{ env.working-directory }}/build/*.par.gz
+          path: ${{ env.working-directory }}/build/${{ env.artifact-name }}.par.gz
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
-    - name: Download provider archive
-      uses: actions/download-artifact@v2
-      with:
-        name: provider-archive
-        path: ${{ env.working-directory }}/build
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/build/*.par.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.working-directory }}/build/*.par.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   artifact_release:
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build

--- a/.github/workflows/lattice-controller.yml
+++ b/.github/workflows/lattice-controller.yml
@@ -2,15 +2,15 @@ name: LATTICE-CONTROLLER
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "lattice-controller/**"
+      - "lattice-controller/**"
     tags:
-    - 'lattice-controller-v*'
+      - "lattice-controller-v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "lattice-controller/**"
+      - "lattice-controller/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,61 +22,132 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    # If your integration tests require nats or redis, run them here
-    - id: run-nats
-      uses: wasmcloud/common-actions/run-nats@main
-    - id: rust-check-action
-      uses: wasmcloud/common-actions/rust-check@main
-      with:
-        working-directory: ${{ env.working-directory }}
+      - uses: actions/checkout@v2
+      # If your integration tests require nats or redis, run them here
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
+
+  install_cross:
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Upload cross binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin/cross
 
   build_artifact:
-    needs: rust_check
-    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: install_cross
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download cross binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin
+
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+        working-directory: ${{ env.working-directory }}
+
+      - name: Build native executable
+        run: |
+          chmod +x ~/.cargo/bin/cross
+          cross build --release --target ${{ matrix.target }}
+        working-directory: ${{ env.working-directory }}
+
+      - name: Upload executable to GH Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_artifact]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: wasmcloud/common-actions/install-wash@main
-      - uses: wasmcloud/common-actions/install-cross@main
+      # Downloads all artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: ${{ env.working-directory }}
 
-      - name: Build full provider archive
-        run: make par-full
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
-      
+
+      - name: Create provider archive
+        working-directory: ${{ env.working-directory }}
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make par
+
+      - name: Insert provider archive targets
+        working-directory: ${{ env.working-directory }}
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+
       - name: Upload provider archive to GH Actions
         uses: actions/upload-artifact@v2
         with:
           name: provider-archive
-          path: ${{ env.working-directory }}/build/*.par.gz
+          path: ${{ env.working-directory }}/build/${{ env.artifact-name }}.par.gz
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
-    - name: Download provider archive
-      uses: actions/download-artifact@v2
-      with:
-        name: provider-archive
-        path: ${{ env.working-directory }}/build
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/build/*.par.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.working-directory }}/build/*.par.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   artifact_release:
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build

--- a/.github/workflows/lattice-controller.yml
+++ b/.github/workflows/lattice-controller.yml
@@ -9,8 +9,8 @@ on:
       - "lattice-controller-v*"
   pull_request:
     branches: [main]
-    paths:
-      - "lattice-controller/**"
+    # paths:
+    #   - "lattice-controller/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/lattice-controller.yml
+++ b/.github/workflows/lattice-controller.yml
@@ -9,8 +9,8 @@ on:
       - "lattice-controller-v*"
   pull_request:
     branches: [main]
-    # paths:
-    #   - "lattice-controller/**"
+    paths:
+      - "lattice-controller/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -32,7 +32,7 @@ jobs:
           working-directory: ${{ env.working-directory }}
 
   install_cross:
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: wasmcloud/common-actions/install-cross@main
@@ -44,7 +44,7 @@ jobs:
 
   build_artifact:
     needs: install_cross
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
         target:

--- a/.github/workflows/nats.yml
+++ b/.github/workflows/nats.yml
@@ -2,15 +2,15 @@ name: NATS
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "nats/**"
+      - "nats/**"
     tags:
-    - 'nats-v*'
+      - "nats-v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "nats/**"
+      - "nats/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -22,60 +22,131 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: run-nats
-      uses: wasmcloud/common-actions/run-nats@main
-    - id: rust-check-action
-      uses: wasmcloud/common-actions/rust-check@main
-      with:
-        working-directory: ${{ env.working-directory }}
+      - uses: actions/checkout@v2
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
+
+  install_cross:
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Upload cross binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin/cross
 
   build_artifact:
-    needs: rust_check
-    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: install_cross
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download cross binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin
+
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+        working-directory: ${{ env.working-directory }}
+
+      - name: Build native executable
+        run: |
+          chmod +x ~/.cargo/bin/cross
+          cross build --release --target ${{ matrix.target }}
+        working-directory: ${{ env.working-directory }}
+
+      - name: Upload executable to GH Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_artifact]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: wasmcloud/common-actions/install-wash@main
-      - uses: wasmcloud/common-actions/install-cross@main
+      # Downloads all artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: ${{ env.working-directory }}
 
-      - name: Build full provider archive
-        run: make par-full
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
-      
+
+      - name: Create provider archive
+        working-directory: ${{ env.working-directory }}
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make par
+
+      - name: Insert provider archive targets
+        working-directory: ${{ env.working-directory }}
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+
       - name: Upload provider archive to GH Actions
         uses: actions/upload-artifact@v2
         with:
           name: provider-archive
-          path: ${{ env.working-directory }}/build/*.par.gz
+          path: ${{ env.working-directory }}/build/${{ env.artifact-name }}.par.gz
 
   github_release:
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
-    - name: Download provider archive
-      uses: actions/download-artifact@v2
-      with:
-        name: provider-archive
-        path: ${{ env.working-directory }}/build
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/build/*.par.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.working-directory }}/build/*.par.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   artifact_release:
-    needs: build_artifact
+    needs: [rust_check, assemble_provider_archive]
     if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build
@@ -86,9 +157,9 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
       - name: Push provider archive to AzureCR
-        uses: wasmcloud/common-actions/oci-artifact-release@main
         env:
           oci-repository: "nats_messaging"
+        uses: wasmcloud/common-actions/oci-artifact-release@main
         with:
           artifact-path: ${{ env.working-directory }}/build/${{ env.oci-repository }}.par.gz
           oci-url: ${{ secrets.AZURECR_PUSH_URL }}
@@ -96,4 +167,3 @@ jobs:
           oci-version: ${{ env.oci-version }}
           oci-username: ${{ secrets.AZURECR_PUSH_USER }}
           oci-password: ${{ secrets.AZURECR_PUSH_PASSWORD }}
-

--- a/.github/workflows/nats.yml
+++ b/.github/workflows/nats.yml
@@ -9,8 +9,8 @@ on:
       - "nats-v*"
   pull_request:
     branches: [main]
-    # paths:
-    #   - "nats/**"
+    paths:
+      - "nats/**"
 
 env:
   CARGO_TERM_COLOR: always
@@ -31,7 +31,7 @@ jobs:
           working-directory: ${{ env.working-directory }}
 
   install_cross:
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: wasmcloud/common-actions/install-cross@main
@@ -43,7 +43,7 @@ jobs:
 
   build_artifact:
     needs: install_cross
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
         target:

--- a/.github/workflows/nats.yml
+++ b/.github/workflows/nats.yml
@@ -9,8 +9,8 @@ on:
       - "nats-v*"
   pull_request:
     branches: [main]
-    paths:
-      - "nats/**"
+    # paths:
+    #   - "nats/**"
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/sqldb-postgres.yml
+++ b/.github/workflows/sqldb-postgres.yml
@@ -9,8 +9,8 @@ on:
       - "sqldb-postgres-v*"
   pull_request:
     branches: [main]
-    paths:
-      - "sqldb-postgres/**"
+    # paths:
+    #   - "sqldb-postgres/**"
   workflow_dispatch:
     inputs:
       release:

--- a/.github/workflows/sqldb-postgres.yml
+++ b/.github/workflows/sqldb-postgres.yml
@@ -2,26 +2,25 @@ name: SQLDB_POSTGRES
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "sqldb-postgres/**"
+      - "sqldb-postgres/**"
     tags:
-    - 'sqldb-postgres-v*'
+      - "sqldb-postgres-v*"
   pull_request:
-    branches: [ main ]
+    branches: [main]
     paths:
-    - "sqldb-postgres/**"
+      - "sqldb-postgres/**"
   workflow_dispatch:
     inputs:
       release:
-        description: 'Build github release (enter y)'
-        default: 'n'
+        description: "Build github release (enter y)"
+        default: "n"
         required: true
       artifact:
-        description: 'Build github release and push artifact (enter y)'
-        default: 'n'
+        description: "Build github release and push artifact (enter y)"
+        default: "n"
         required: true
-
 
 env:
   CARGO_TERM_COLOR: always
@@ -34,78 +33,149 @@ jobs:
   rust_check:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: rust-check-action
-      uses: wasmcloud/common-actions/rust-check@main
-      with:
-        working-directory: ${{ env.working-directory }}
-        # disable testing with "cargo test" since this will run 'make test'
-        test-options: --no-run
+      - uses: actions/checkout@v2
+      - id: rust-check-action
+        uses: wasmcloud/common-actions/rust-check@main
+        with:
+          working-directory: ${{ env.working-directory }}
+          # disable testing with "cargo test" since this will run 'make test'
+          test-options: --no-run
 
   make_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - id: run-nats
-      uses: wasmcloud/common-actions/run-nats@main
-    - name: Run tests via Makefile
-      run: make test
-      shell: bash
-      working-directory: ${{ env.working-directory }}
+      - uses: actions/checkout@v2
+      - id: run-nats
+        uses: wasmcloud/common-actions/run-nats@main
+      - name: Run tests via Makefile
+        run: make test
+        shell: bash
+        working-directory: ${{ env.working-directory }}
+
+  install_cross:
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    runs-on: ubuntu-latest
+    steps:
+      - uses: wasmcloud/common-actions/install-cross@main
+      - name: Upload cross binary
+        uses: actions/upload-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin/cross
 
   build_artifact:
-    needs: [ rust_check, make_test ]
-    # run on tag push or manual with 'y'
-    if: ${{ ( startswith(github.ref, 'refs/tags/') || github.events.inputs.artifact == 'y' || github.events.inputs.release == 'y' ) }}
+    needs: install_cross
+    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-apple-darwin
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+          - armv7-unknown-linux-gnueabihf
+          - x86_64-pc-windows-gnu
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Download cross binary
+        uses: actions/download-artifact@v3
+        with:
+          name: cross
+          path: ~/.cargo/bin
+
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
+        working-directory: ${{ env.working-directory }}
+
+      - name: Build native executable
+        run: |
+          chmod +x ~/.cargo/bin/cross
+          cross build --release --target ${{ matrix.target }}
+        working-directory: ${{ env.working-directory }}
+
+      - name: Upload executable to GH Actions
+        uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.target }}
+          if-no-files-found: error
+          path: |
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}
+            ${{ env.working-directory }}/target/${{ matrix.target }}/release/${{ env.artifact-name }}.exe
+
+  assemble_provider_archive:
+    needs: [build_artifact]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: wasmcloud/common-actions/install-wash@main
-      - uses: wasmcloud/common-actions/install-cross@main
+      # Downloads all artifacts
+      - uses: actions/download-artifact@v3
+        with:
+          path: ${{ env.working-directory }}
 
-      - name: Build full provider archive
-        run: make par-full
+      - name: Determine artifact name
+        run: |
+          echo "artifact-name=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[0].targets[0].name')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
-      
+
+      - name: Create provider archive
+        working-directory: ${{ env.working-directory }}
+        run: |
+          mkdir -p target/release
+          mv x86_64-unknown-linux-gnu/${{ env.artifact-name }} target/release/
+          make par
+
+      - name: Insert provider archive targets
+        working-directory: ${{ env.working-directory }}
+        run: |
+          wash par insert --arch x86_64-macos   --binary x86_64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-linux  --binary aarch64-unknown-linux-gnu/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch aarch64-macos  --binary aarch64-apple-darwin/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch armv7-linux    --binary armv7-unknown-linux-gnueabihf/${{ env.artifact-name }} build/${{ env.artifact-name }}.par.gz
+          wash par insert --arch x86_64-windows --binary x86_64-pc-windows-gnu/${{ env.artifact-name }}.exe build/${{ env.artifact-name }}.par.gz
+
       - name: Upload provider archive to GH Actions
         uses: actions/upload-artifact@v2
         with:
           name: provider-archive
-          path: ${{ env.working-directory }}/build/*.par.gz
+          path: ${{ env.working-directory }}/build/${{ env.artifact-name }}.par.gz
 
   github_release:
-    if: ${{ ( startswith(github.ref, 'refs/tags/') || github.events.inputs.artifact == 'y' || github.events.inputs.release == 'y' ) }}
-    needs: build_artifact
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    needs: [rust_check, assemble_provider_archive]
     runs-on: ubuntu-latest
     steps:
-    - name: Download provider archive
-      uses: actions/download-artifact@v2
-      with:
-        name: provider-archive
-        path: ${{ env.working-directory }}/build
+      - name: Download provider archive
+        uses: actions/download-artifact@v3
+        with:
+          name: provider-archive
+          path: ${{ env.working-directory }}/build
 
-    - name: Release
-      uses: softprops/action-gh-release@v1
-      with:
-        files: ${{ env.working-directory }}/build/*.par.gz
-        token: ${{ secrets.GITHUB_TOKEN }}
-        prerelease: true
-        draft: false
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          files: ${{ env.working-directory }}/build/*.par.gz
+          token: ${{ secrets.GITHUB_TOKEN }}
+          prerelease: true
+          draft: false
 
   artifact_release:
-    needs: build_artifact
-    if: ${{ ( startswith(github.ref, 'refs/tags/') || github.events.inputs.artifact == 'y' ) }}
+    needs: [rust_check, assemble_provider_archive]
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Download provider archive
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v3
         with:
           name: provider-archive
           path: ${{ env.working-directory }}/build
 
       - name: Determine artifact metadata
         run: |
+          echo "oci-repository=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].name' | sed 's/wasmcloud-provider-//')" >> $GITHUB_ENV
           echo "oci-version=$(cargo metadata --no-deps --format-version 1 | jq -r '.packages[].version')" >> $GITHUB_ENV
         working-directory: ${{ env.working-directory }}
 

--- a/.github/workflows/sqldb-postgres.yml
+++ b/.github/workflows/sqldb-postgres.yml
@@ -9,8 +9,8 @@ on:
       - "sqldb-postgres-v*"
   pull_request:
     branches: [main]
-    # paths:
-    #   - "sqldb-postgres/**"
+    paths:
+      - "sqldb-postgres/**"
   workflow_dispatch:
     inputs:
       release:
@@ -53,7 +53,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
 
   install_cross:
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     runs-on: ubuntu-latest
     steps:
       - uses: wasmcloud/common-actions/install-cross@main
@@ -65,7 +65,7 @@ jobs:
 
   build_artifact:
     needs: install_cross
-    # if: startswith(github.ref, 'refs/tags/') # Only run on tag push
+    if: startswith(github.ref, 'refs/tags/') # Only run on tag push
     strategy:
       matrix:
         target:


### PR DESCRIPTION
This PR changes the capability provider builds (just httpclient for easier reviews to start) to build in a matrix instead of in sequence. This cuts the release time of a provider to build+test+build provider archive down to 10ish minutes rather than the status quo of 45 minutes.

Here's a previous run: https://github.com/wasmCloud/capability-providers/actions/runs/1919866317
Here's a successful run from this PR before I re-enabled only running release on tag push: https://github.com/wasmCloud/capability-providers/actions/runs/2418640152