### PR TITLE
Updated kvredis to support overridable config_json default URL and support retries

### DIFF
--- a/kvredis/.gitignore
+++ b/kvredis/.gitignore
@@ -1,3 +1,4 @@
 build
 target
 .idea
+*.rdb

--- a/kvredis/Cargo.lock
+++ b/kvredis/Cargo.lock
@@ -3000,7 +3000,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-kvredis"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "async-trait",
  "atty",

--- a/kvredis/Cargo.lock
+++ b/kvredis/Cargo.lock
@@ -67,6 +67,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1485d4d2cc45e7b201ee3767015c96faa5904387c9d87c6efdd0fb511f12d305"
 
 [[package]]
+name = "arc-swap"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "983cd8b9d4b02a6dc6ffa557262eb5858a27a0038ffffe21a0f133eaa819a164"
+
+[[package]]
 name = "ascii_tree"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1766,10 +1772,12 @@ version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a80b5f38d7f5a020856a0e16e40a9cfabf88ae8f0e4c2dcd8a3114c1e470852"
 dependencies = [
+ "arc-swap",
  "async-trait",
  "bytes",
  "combine",
  "dtoa",
+ "futures 0.3.23",
  "futures-util",
  "itoa 0.4.8",
  "percent-encoding",

--- a/kvredis/Cargo.toml
+++ b/kvredis/Cargo.toml
@@ -12,7 +12,7 @@ chrono = "0.4"
 crossbeam = "0.8"
 futures = "0.3"
 once_cell = "1.8"
-redis = { version = "0.21", features = ["tokio-comp"] }
+redis = { version = "0.21", features = ["tokio-comp", "aio", "connection-manager"] }
 rmp-serde = "1.1.0"
 serde_bytes = "0.11"
 serde_json = "1.0"

--- a/kvredis/Cargo.toml
+++ b/kvredis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-kvredis"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [dependencies]

--- a/kvredis/README.md
+++ b/kvredis/README.md
@@ -4,12 +4,25 @@ This capability provider implements the `wasmcloud:keyvalue` capability contract
 
 Build with `make`. Test with `make test`.
 
-The test program in tests/kv_test.rs has example code for using 
+The test program in tests/kv_test.rs has example code for using
 each of this provider's functions.
 
 ## Link Definition Configuration Settings
+
 The following is a list of configuration settings available in the link definition.
 
-| Property | Description |
-| :--- | :--- |
-| `URL` | The connection string URL for the Redis database. Note that all authentication information must also be contained in this URL |
+| Property | Description                                                                                                                   |
+| :------- | :---------------------------------------------------------------------------------------------------------------------------- |
+| `URL`    | The connection string URL for the Redis database. Note that all authentication information must also be contained in this URL |
+
+## Configuring a default Redis URL
+
+This provider also accepts a default URL as a configuration value on startup to override the default URL. This can be useful to easily setup multiple actors to access the same default endpoint without specifying the URL in the link definition.
+
+```json
+{ "url": "redis://127.0.0.1:6380" }
+```
+
+```
+wash ctl start wasmcloud.azurecr.io/kvredis:0.18.0 --config-json /path/to/config.json
+```

--- a/kvredis/src/main.rs
+++ b/kvredis/src/main.rs
@@ -34,12 +34,26 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
+struct RedisConnection {
+    connection: Connection,
+    redis_url: String,
+}
+
+impl RedisConnection {
+    fn new(connection: Connection, redis_url: &str) -> Self {
+        RedisConnection {
+            connection,
+            redis_url: redis_url.to_owned(),
+        }
+    }
+}
+
 /// Redis keyValue provider implementation.
 #[derive(Default, Clone, Provider)]
 #[services(KeyValue)]
 struct KvRedisProvider {
     // store redis connections per actor
-    actors: Arc<RwLock<HashMap<String, RwLock<Connection>>>>,
+    actors: Arc<RwLock<HashMap<String, RwLock<RedisConnection>>>>,
 }
 /// use default implementations of provider message handlers
 impl ProviderDispatch for KvRedisProvider {}
@@ -61,7 +75,10 @@ impl ProviderHandler for KvRedisProvider {
         if let Ok(client) = redis::Client::open(redis_url) {
             if let Ok(connection) = client.get_async_connection().await {
                 let mut update_map = self.actors.write().await;
-                update_map.insert(ld.actor_id.to_string(), RwLock::new(connection));
+                update_map.insert(
+                    ld.actor_id.to_string(),
+                    RwLock::new(RedisConnection::new(connection, redis_url)),
+                );
             } else {
                 warn!(
                     "Could not create Redis connection for actor {}, keyvalue operations will fail",
@@ -312,6 +329,39 @@ impl KvRedisProvider {
             .ok_or_else(|| RpcError::InvalidParameter(format!("No Redis connection found for {}. Please ensure the URL supplied in the link definition is a valid Redis URL", actor_id)))?;
         // get write lock on this actor's connection
         let mut con = rc.write().await;
-        cmd.query_async(con.deref_mut()).await.map_err(to_rpc_err)
+        match cmd.query_async(&mut con.deref_mut().connection).await {
+            // If the error is IO or connection dropped, try to reconnect
+            Err(err) if err.is_connection_dropped() || err.is_io_error() => {
+                let redis_url = con.redis_url.clone();
+                // Explicitly drop read locks here so we can take a write lock on the actor map
+                drop(con);
+                drop(rd);
+
+                //TODO: refactoring opportunity from linkdef
+                if let Ok(client) = redis::Client::open(redis_url.clone()) {
+                    if let Ok(connection) = client.get_async_connection().await {
+                        info!("Connection re-established, replacing in actor map");
+                        let mut update_map = self.actors.write().await;
+                        update_map.insert(
+                            actor_id.to_string(),
+                            RwLock::new(RedisConnection::new(connection, &redis_url)),
+                        );
+                    } else {
+                        warn!(
+                            "Could not re-create Redis connection for actor {}, keyvalue operations will fail",
+                            actor_id
+                        );
+                    }
+                } else {
+                    warn!(
+                        "Could not re-create Redis client for actor {}, keyvalue operations will fail",
+                        actor_id
+                    );
+                }
+                Err(to_rpc_err(err))
+            }
+            //TODO: meaningful here
+            res => res.map_err(to_rpc_err),
+        }
     }
 }

--- a/kvredis/src/main.rs
+++ b/kvredis/src/main.rs
@@ -11,6 +11,7 @@
 use std::{collections::HashMap, convert::Infallible, ops::DerefMut, sync::Arc};
 
 use redis::{aio::ConnectionManager, FromRedisValue, RedisError};
+use serde::Deserialize;
 use tokio::sync::RwLock;
 use tracing::{info, instrument, warn};
 use wasmbus_rpc::provider::prelude::*;
@@ -22,11 +23,27 @@ use wasmcloud_interface_keyvalue::{
 const REDIS_URL_KEY: &str = "URL";
 const DEFAULT_CONNECT_URL: &str = "redis://0.0.0.0:6379/";
 
+#[derive(Deserialize)]
+struct KvRedisConfig {
+    /// Default URL to connect when actor doesn't provide one on a link
+    url: String,
+}
+
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // handle lattice control messages and forward rpc to the provider dispatch
-    // returns when provider receives a shutdown control message
-    provider_main(
-        KvRedisProvider::default(),
+    let hd = load_host_data()?;
+
+    let default_connect_url = if let Some(raw_config) = hd.config_json.as_ref() {
+        match serde_json::from_str(&raw_config) {
+            Ok(KvRedisConfig { url }) => url,
+            _ => DEFAULT_CONNECT_URL.to_string(),
+        }
+    } else {
+        DEFAULT_CONNECT_URL.to_string()
+    };
+
+    provider_start(
+        KvRedisProvider::new(&default_connect_url),
+        hd,
         Some("KeyValue Redis Provider".to_string()),
     )?;
 
@@ -40,6 +57,17 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 struct KvRedisProvider {
     // store redis connections per actor
     actors: Arc<RwLock<HashMap<String, RwLock<ConnectionManager>>>>,
+    // Default connection URL for actors without a `URL` link value
+    default_connect_url: String,
+}
+
+impl KvRedisProvider {
+    fn new(default_connect_url: &str) -> Self {
+        KvRedisProvider {
+            default_connect_url: default_connect_url.to_string(),
+            ..Default::default()
+        }
+    }
 }
 /// use default implementations of provider message handlers
 impl ProviderDispatch for KvRedisProvider {}
@@ -53,23 +81,21 @@ impl ProviderHandler for KvRedisProvider {
     /// If the link is allowed, return true, otherwise return false to deny the link.
     #[instrument(level = "debug", skip(self, ld), fields(actor_id = %ld.actor_id))]
     async fn put_link(&self, ld: &LinkDefinition) -> RpcResult<bool> {
-        let redis_url = match ld.values.get(REDIS_URL_KEY) {
-            Some(v) => v.as_str(),
-            None => DEFAULT_CONNECT_URL,
-        };
+        let redis_url = ld
+            .values
+            .get(REDIS_URL_KEY)
+            .unwrap_or_else(|| &self.default_connect_url);
 
-        if let Ok(client) = redis::Client::open(redis_url) {
-            let mut update_map = self.actors.write().await;
-
-            update_map.insert(
-                ld.actor_id.to_string(),
-                RwLock::new(
-                    client
-                        .get_tokio_connection_manager()
-                        .await
-                        .map_err(to_rpc_err)?,
-                ),
-            );
+        if let Ok(client) = redis::Client::open(redis_url.clone()) {
+            if let Ok(conn_manager) = client.get_tokio_connection_manager().await {
+                let mut update_map = self.actors.write().await;
+                update_map.insert(ld.actor_id.to_string(), RwLock::new(conn_manager));
+            } else {
+                warn!(
+                    "Could not create Redis connection manager for actor {}, keyvalue operations will fail",
+                    ld.actor_id
+                );
+            }
         } else {
             warn!(
                 "Could not create Redis client for actor {}, keyvalue operations will fail",

--- a/kvredis/src/main.rs
+++ b/kvredis/src/main.rs
@@ -10,10 +10,7 @@
 //!
 use std::{collections::HashMap, convert::Infallible, ops::DerefMut, sync::Arc};
 
-use redis::{
-    aio::{Connection, ConnectionManager},
-    FromRedisValue, RedisError,
-};
+use redis::{aio::ConnectionManager, FromRedisValue, RedisError};
 use tokio::sync::RwLock;
 use tracing::{info, instrument, warn};
 use wasmbus_rpc::provider::prelude::*;

--- a/kvredis/src/main.rs
+++ b/kvredis/src/main.rs
@@ -62,7 +62,6 @@ impl ProviderHandler for KvRedisProvider {
         };
 
         if let Ok(client) = redis::Client::open(redis_url) {
-            // if let Ok(connection) = client.get_async_connection().await {
             let mut update_map = self.actors.write().await;
 
             update_map.insert(
@@ -74,12 +73,6 @@ impl ProviderHandler for KvRedisProvider {
                         .map_err(to_rpc_err)?,
                 ),
             );
-            // } else {
-            //     warn!(
-            //         "Could not create Redis connection for actor {}, keyvalue operations will fail",
-            //         ld.actor_id
-            //     )
-            // }
         } else {
             warn!(
                 "Could not create Redis client for actor {}, keyvalue operations will fail",


### PR DESCRIPTION
This PR changes the Redis connection to a ConnectionManager which automatically supervises the connection and will reconnect if Redis temporarily disconnects.

If Redis is down, users get an error message like:
```
{"error":"Host send error redis error: Reconnecting failed: Connection refused (os error 61)"}
```

Which is reasonable for the connection being down.

Edit: Smushed another change into this PR which I'm fine breaking out if desired, but I wanted to allow users to override the default URL as config_json. Default functionality is unchanged