### PR TITLE
Accept uppercase URL parameter, correct default connect

### DIFF
--- a/kvredis/Cargo.lock
+++ b/kvredis/Cargo.lock
@@ -2923,7 +2923,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-kvredis"
-version = "0.19.0"
+version = "0.19.1"
 dependencies = [
  "async-trait",
  "atty",

--- a/kvredis/Cargo.toml
+++ b/kvredis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-kvredis"
-version = "0.19.0"
+version = "0.19.1"
 edition = "2021"
 
 [dependencies]

--- a/kvredis/src/main.rs
+++ b/kvredis/src/main.rs
@@ -84,7 +84,9 @@ impl ProviderHandler for KvRedisProvider {
     async fn put_link(&self, ld: &LinkDefinition) -> RpcResult<bool> {
         let redis_url = ld
             .values
-            .get(REDIS_URL_KEY)
+            .iter()
+            .find(|(key, _value)| key.eq_ignore_ascii_case(REDIS_URL_KEY))
+            .map(|(_key, url)| url)
             .unwrap_or_else(|| &self.default_connect_url);
 
         if let Ok(client) = redis::Client::open(redis_url.clone()) {


### PR DESCRIPTION
This PR ensures that:
- The kvredis provider can accept uppercase, lowercase, or initial caps `URL` values to prevent small typos
- The kvredis provider connects to 127.0.0.1 instead of 0.0.0.0 by default

Edit: apparently this only works for the `config_json` parameter... will push another commit to fix this for the linkdef parameter