### PR TITLE
feat: sanitize blobstore paths

### DIFF
--- a/blobstore-fs/Makefile
+++ b/blobstore-fs/Makefile
@@ -7,16 +7,11 @@ PROJECT = blobstore_fs
 VERSION  = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] .version' | head -1)
 REVISION = 0
 
-CARGO ?= cargo
-
 # builds are 'release'
 # If using debug builds, change bin_path in provider_test_config.toml
 TEST_FLAGS := --release -- --nocapture
 
 include ../build/makefiles/provider.mk
-
-dev:
-	$(CARGO) watch
 
 ifeq ($(shell nc -zt -w1 127.0.0.1 4222 || echo fail),fail)
 test::

--- a/blobstore-fs/Makefile
+++ b/blobstore-fs/Makefile
@@ -7,18 +7,22 @@ PROJECT = blobstore_fs
 VERSION  = $(shell cargo metadata --no-deps --format-version 1 | jq -r '.packages[] .version' | head -1)
 REVISION = 0
 
+CARGO ?= cargo
+
 # builds are 'release'
 # If using debug builds, change bin_path in provider_test_config.toml
 TEST_FLAGS := --release -- --nocapture
 
 include ../build/makefiles/provider.mk
 
+dev:
+	$(CARGO) watch
 
 ifeq ($(shell nc -zt -w1 127.0.0.1 4222 || echo fail),fail)
 test::
 	@killall blobstore_fs || true
 	docker run --rm -d --name fs-provider-test -p 127.0.0.1:4222:4222 nats:2.8.4-alpine -js
-	RUST_BACKTRACE=1 RUST_LOG=debug cargo test $(TEST_FLAGS) 
+	RUST_BACKTRACE=1 RUST_LOG=debug cargo test $(TEST_FLAGS)
 	docker stop fs-provider-test
 else
 test::

--- a/blobstore-fs/src/main.rs
+++ b/blobstore-fs/src/main.rs
@@ -602,7 +602,7 @@ impl Blobstore for FsProvider {
     async fn put_chunk(&self, ctx: &Context, arg: &PutChunkRequest) -> RpcResult<()> {
         info!("Called put_chunk: {:?}", arg);
 
-        // Early return of storing the chunk simply (happy path)
+        // In the simplest case we can simply store the chunk (happy path)
         if !arg.cancel_and_remove {
             self.store_chunk(ctx, &arg.chunk, &arg.stream_id).await?;
             return Ok(());

--- a/blobstore-fs/src/main.rs
+++ b/blobstore-fs/src/main.rs
@@ -84,8 +84,8 @@ impl FsProvider {
             }
         }
 
-        // At this point, the root iterator has ben exhausted and the remaining components
-        // are the paths underneath the root
+        // At this point, the root iterator has ben exhausted
+        // and the remaining components are the paths beneath the root
 
         Ok(joined_abs)
     }

--- a/blobstore-fs/src/main.rs
+++ b/blobstore-fs/src/main.rs
@@ -718,6 +718,7 @@ mod tests {
         let provider = FsProvider::default();
         let res = provider
             .resolve_subpath(&PathBuf::from("./"), "../")
+            .await
             .unwrap_err();
         assert_eq!(res.kind(), IoErrorKind::PermissionDenied);
     }

--- a/blobstore-fs/src/main.rs
+++ b/blobstore-fs/src/main.rs
@@ -686,6 +686,7 @@ impl Blobstore for FsProvider {
 mod tests {
     use super::FsProvider;
     use std::path::PathBuf;
+    use std::io::ErrorKind as IOErrorKind;
 
     /// Ensure that only safe subpaths are resolved
     #[test]
@@ -698,6 +699,7 @@ mod tests {
     #[test]
     fn resolve_fail_ancestor() {
         let provider = FsProvider::default();
-        assert!(matches!(provider.resolve_subpath(&PathBuf::from("./"), "./././"), Ok(_)));
+        let res = provider.resolve_subpath(&PathBuf::from("./"), "../").unwrap_err();
+        assert_eq!(res.kind(), IOErrorKind::PermissionDenied);
     }
 }

--- a/blobstore-fs/src/main.rs
+++ b/blobstore-fs/src/main.rs
@@ -65,12 +65,13 @@ impl FsProvider {
         let joined = root_abs.join(Path::new(path.as_ref()));
         let joined_abs = joined.canonicalize()?;
 
-        // If the path is shorter we know something is wrong
+        // Check components of either path
         let mut joined_abs_iter = joined_abs.components();
         for root_part in root_abs.components() {
             let joined_part = joined_abs_iter.next();
 
-            // If the joined absolute path is shorter or doesn't match, we're out
+            // If the joined path is shorter or doesn't match
+            // for the duration of the root, path is suspect
             if joined_part.is_none() || joined_part != Some(root_part) {
                 return Err(IOError::new(
                     IOErrorKind::PermissionDenied,

--- a/blobstore-fs/src/main.rs
+++ b/blobstore-fs/src/main.rs
@@ -196,7 +196,7 @@ impl FsProvider {
             upload_chunks.insert(s_id.clone(), next_offset);
         }
 
-        let chunk_obj_subpath = Path::join(Path::new(&chunk.container_id), &chunk.object_id);
+        let chunk_obj_subpath = Path::new(&chunk.container_id).join(&chunk.object_id);
         let chunk_obj_path = self.resolve_subpath(&root, &chunk_obj_subpath)?;
 
         let mut file = OpenOptions::new().create(false).append(true).open(chunk_obj_path)?;
@@ -416,7 +416,7 @@ impl Blobstore for FsProvider {
         info!("Called object_exists({:?})", container);
 
         let root = self.get_root(ctx).await?;
-        let file_subpath = Path::join(Path::new(&container.container_id), &container.object_id);
+        let file_subpath = Path::new(&container.container_id).join(&container.object_id);
         let file_path = self.resolve_subpath(&root, &file_subpath)?;
 
         match File::open(file_path) {
@@ -436,7 +436,7 @@ impl Blobstore for FsProvider {
         info!("Called get_object_info({:?})", container);
 
         let root = self.get_root(ctx).await?;
-        let file_subpath = Path::join(Path::new(&container.container_id), &container.object_id);
+        let file_subpath = Path::new(&container.container_id).join(&container.object_id);
         let file_path = self.resolve_subpath(&root, &file_subpath)?;
 
         let metadata = metadata(file_path)?;
@@ -543,7 +543,7 @@ impl Blobstore for FsProvider {
         let mut errors = Vec::new();
 
         for object in &arg.objects {
-            let object_subpath = Path::join(Path::new(&arg.container_id), &object);
+            let object_subpath = Path::new(&arg.container_id).join(&object);
             let object_path = self.resolve_subpath(&root, &object_subpath)?;
 
             if let Err(e) = remove_file(object_path.as_path()) {
@@ -609,7 +609,7 @@ impl Blobstore for FsProvider {
 
         // Determine the path to the file
         let root = &self.get_root(ctx).await?;
-        let file_subpath = Path::join(Path::new(&arg.chunk.container_id), &arg.chunk.object_id);
+        let file_subpath = Path::new(&arg.chunk.container_id).join(&arg.chunk.object_id);
         let file_path = self.resolve_subpath(&root, &file_subpath)?;
 
         // Remove the file
@@ -634,7 +634,7 @@ impl Blobstore for FsProvider {
 
         // Determine path to object file
         let root = &self.get_root(ctx).await?;
-        let object_subpath = Path::join(Path::new(&req.container_id), &req.object_id); 
+        let object_subpath = Path::new(&req.container_id).join(&req.object_id);
         let file_path = self.resolve_subpath(&root, &object_subpath)?;
 
         // Read the file in

--- a/build/makefiles/provider.mk
+++ b/build/makefiles/provider.mk
@@ -8,7 +8,7 @@
 # top_targets      # list of targets that are applicable for this project
 #
 
-top_targets     ?= all par par-full test clean 
+top_targets     ?= all par par-full test clean
 
 platform_id = $(shell uname -s)
 platform = $$( \
@@ -29,6 +29,7 @@ link_name ?= default
 NAME ?= $(PROJECT)
 
 WASH ?= wash
+CARGO ?= cargo
 
 oci_url_base ?= localhost:5000/v2
 oci_url      ?= $(oci_url_base)/$(bin_name):$(VERSION)
@@ -85,7 +86,7 @@ $(dest_par): $(bin_target0) Makefile Cargo.toml
 	@mkdir -p $(dir $(dest_par))
 	bin_src=$(bin_target0);  \
 	if [ $(par_target0) = "x86_64-pc-windows-gnu" ] || \
-	   [ $(par_target0) = "x86_64-pc-windows-msvc" ] ; then \
+		 [ $(par_target0) = "x86_64-pc-windows-msvc" ] ; then \
 		bin_src=$$bin_src.exe;  \
 	fi; \
 	$(WASH) par create \
@@ -103,14 +104,14 @@ $(dest_par): $(bin_target0) Makefile Cargo.toml
 # par-full adds all the other targets to the base par
 par-full: $(dest_par) $(bin_targets)
 	for target in $(par_targets); do \
-	    target_dest=target/$${target}/release/$(bin_name);  \
+			target_dest=target/$${target}/release/$(bin_name);  \
 		if [ $$target = "x86_64-pc-windows-gnu" ]; then \
 			target_dest=$$target_dest.exe;  \
 		fi; \
-	    par_arch=`echo -n $$target | sed -E 's/([^-]+)-([^-]+)-([^-]+)(-gnu.*)?/\1-\3/' | sed 's/darwin/macos/'`; \
+			par_arch=`echo -n $$target | sed -E 's/([^-]+)-([^-]+)-([^-]+)(-gnu.*)?/\1-\3/' | sed 's/darwin/macos/'`; \
 		echo building $$par_arch; \
 		if [ $$target_dest != $(cross_target0) ] && [ -f $$target_dest ]; then \
-		    $(WASH) par insert --arch $$par_arch --binary $$target_dest $(dest_par); \
+				$(WASH) par insert --arch $$par_arch --binary $$target_dest $(dest_par); \
 		fi; \
 	done
 
@@ -172,6 +173,9 @@ endif
 
 
 ifeq ($(wildcard ./Cargo.toml),./Cargo.toml)
+dev::
+	$(CARGO) watch
+
 build::
 	cargo build
 

--- a/build/makefiles/provider.mk
+++ b/build/makefiles/provider.mk
@@ -86,7 +86,7 @@ $(dest_par): $(bin_target0) Makefile Cargo.toml
 	@mkdir -p $(dir $(dest_par))
 	bin_src=$(bin_target0);  \
 	if [ $(par_target0) = "x86_64-pc-windows-gnu" ] || \
-		 [ $(par_target0) = "x86_64-pc-windows-msvc" ] ; then \
+	   [ $(par_target0) = "x86_64-pc-windows-msvc" ] ; then \
 		bin_src=$$bin_src.exe;  \
 	fi; \
 	$(WASH) par create \
@@ -104,14 +104,14 @@ $(dest_par): $(bin_target0) Makefile Cargo.toml
 # par-full adds all the other targets to the base par
 par-full: $(dest_par) $(bin_targets)
 	for target in $(par_targets); do \
-			target_dest=target/$${target}/release/$(bin_name);  \
+	    target_dest=target/$${target}/release/$(bin_name);  \
 		if [ $$target = "x86_64-pc-windows-gnu" ]; then \
 			target_dest=$$target_dest.exe;  \
 		fi; \
-			par_arch=`echo -n $$target | sed -E 's/([^-]+)-([^-]+)-([^-]+)(-gnu.*)?/\1-\3/' | sed 's/darwin/macos/'`; \
+	    par_arch=`echo -n $$target | sed -E 's/([^-]+)-([^-]+)-([^-]+)(-gnu.*)?/\1-\3/' | sed 's/darwin/macos/'`; \
 		echo building $$par_arch; \
 		if [ $$target_dest != $(cross_target0) ] && [ -f $$target_dest ]; then \
-				$(WASH) par insert --arch $$par_arch --binary $$target_dest $(dest_par); \
+		    $(WASH) par insert --arch $$par_arch --binary $$target_dest $(dest_par); \
 		fi; \
 	done
 


### PR DESCRIPTION
Signed-off-by: Victor Adossi <vadossi@cosmonic.com>

This commit sanitizes the blobstore paths to resolve #200.

The primary check that is performed on the paths is ensuring that paths cannot rise *above* the given root directory.