### PR TITLE
Adding support for default connection configuration

### DIFF
--- a/nats/Cargo.lock
+++ b/nats/Cargo.lock
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-nats"
-version = "0.15.1"
+version = "0.16.0"
 dependencies = [
  "async-nats",
  "async-trait",

--- a/nats/Cargo.lock
+++ b/nats/Cargo.lock
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-nats"
-version = "0.15.0"
+version = "0.15.1"
 dependencies = [
  "async-nats",
  "async-trait",
@@ -3076,19 +3076,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a3e1820f08b8513f676f7ab6c1f99ff312fb97b553d30ff4dd86f9f15728aa7"
 dependencies = [
  "windows_aarch64_gnullvm",
- "windows_aarch64_msvc 0.42.0",
- "windows_i686_gnu 0.42.0",
- "windows_i686_msvc 0.42.0",
- "windows_x86_64_gnu 0.42.0",
+ "windows_aarch64_msvc 0.42.1",
+ "windows_i686_gnu 0.42.1",
+ "windows_i686_msvc 0.42.1",
+ "windows_x86_64_gnu 0.42.1",
  "windows_x86_64_gnullvm",
- "windows_x86_64_msvc 0.42.0",
+ "windows_x86_64_msvc 0.42.1",
 ]
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d2aa71f6f0cbe00ae5167d90ef3cfe66527d6f613ca78ac8024c3ccab9a19e"
+checksum = "8c9864e83243fdec7fc9c5444389dcbbfd258f745e7853198f365e3c4968a608"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -3098,9 +3098,9 @@ checksum = "9bb8c3fd39ade2d67e9874ac4f3db21f0d710bee00fe7cab16949ec184eeaa47"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd0f252f5a35cac83d6311b2e795981f5ee6e67eb1f9a7f64eb4500fbc4dcdb4"
+checksum = "4c8b1b673ffc16c47a9ff48570a9d85e25d265735c503681332589af6253c6c7"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3110,9 +3110,9 @@ checksum = "180e6ccf01daf4c426b846dfc66db1fc518f074baa793aa7d9b9aaeffad6a3b6"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeae19f6716841636c28d695375df17562ca208b2b7d0dc47635a50ae6c5de7"
+checksum = "de3887528ad530ba7bdbb1faa8275ec7a1155a45ffa57c37993960277145d640"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3122,9 +3122,9 @@ checksum = "e2e7917148b2812d1eeafaeb22a97e4813dfa60a3f8f78ebe204bcc88f12f024"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c12f65daa39dd2babe6e442988fc329d6243fdce47d7d2d155b8d874862246"
+checksum = "bf4d1122317eddd6ff351aa852118a2418ad4214e6613a50e0191f7004372605"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3134,15 +3134,15 @@ checksum = "4dcd171b8776c41b97521e5da127a2d86ad280114807d0b2ab1e462bc764d9e1"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf7b1b21b5362cbc318f686150e5bcea75ecedc74dd157d874d754a2ca44b0ed"
+checksum = "c1040f221285e17ebccbc2591ffdc2d44ee1f9186324dd3e84e99ac68d699c45"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09d525d2ba30eeb3297665bd434a54297e4170c7f1a44cad4ef58095b4cd2028"
+checksum = "628bfdf232daa22b0d64fdb62b09fcc36bb01f05a3939e20ab73aaf9470d0463"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3152,9 +3152,9 @@ checksum = "c811ca4a8c853ef420abd8592ba53ddbbac90410fab6903b3e79972a631f7680"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.42.0"
+version = "0.42.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f40009d85759725a34da6d89a94e63d7bdc50a862acf0dbc7c8e488f1edcb6f5"
+checksum = "447660ad36a13288b1db4d4248e857b510e8c3a225c822ba4fb748c0aafecffd"
 
 [[package]]
 name = "winreg"

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-nats"
-version = "0.15.1"
+version = "0.16.0"
 edition = "2021"
 
 [dependencies]

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-nats"
-version = "0.15.0"
+version = "0.15.1"
 edition = "2021"
 
 [dependencies]

--- a/nats/src/main.rs
+++ b/nats/src/main.rs
@@ -25,14 +25,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // returns when provider receives a shutdown control message
     let host_data = load_host_data()?;
     let provider = if let Some(c) = host_data.config_json.as_ref() {
-        // fall back to the safe default if the JSON is bad
-        let config: ConnectionConfig = match serde_json::from_str(c) {
-            Ok(c) => c,
-            Err(e) => {
-                error!("Failed to parse host data config JSON: {e:?}");
-                ConnectionConfig::default()
-            }
-        };
+        let config: ConnectionConfig = serde_json::from_str(c)?;
         NatsMessagingProvider {
             default_config: config,
             ..Default::default()

--- a/nats/src/main.rs
+++ b/nats/src/main.rs
@@ -25,7 +25,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // returns when provider receives a shutdown control message
     let host_data = load_host_data()?;
     let provider = if let Some(c) = host_data.config_json.as_ref() {
-        let config: ConnectionConfig = serde_json::from_str(c)?;
+        let config: ConnectionConfig = serde_json::from_str(c)
+            .expect("JSON deserialization from connection config should have worked");
         NatsMessagingProvider {
             default_config: config,
             ..Default::default()

--- a/nats/src/main.rs
+++ b/nats/src/main.rs
@@ -241,7 +241,13 @@ impl ProviderHandler for NatsMessagingProvider {
         let config = if ld.values.is_empty() {
             self.default_config.clone()
         } else {
-            ConnectionConfig::new_from(&ld.values)?
+            match ConnectionConfig::new_from(&ld.values) {
+                Ok(cc) => cc,
+                Err(e) => {
+                    error!("Failed to build connection configuration: {e:?}");
+                    return Ok(false);
+                }
+            }
         };
         let conn = self.connect(config, ld).await?;
 

--- a/nats/src/main.rs
+++ b/nats/src/main.rs
@@ -23,10 +23,24 @@ const ENV_NATS_CLIENT_SEED: &str = "CLIENT_SEED";
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // handle lattice control messages and forward rpc to the provider dispatch
     // returns when provider receives a shutdown control message
-    provider_main(
-        NatsMessagingProvider::default(),
-        Some("Nats Messaging Provider".to_string()),
-    )?;
+    let host_data = load_host_data()?;
+    let provider = if let Some(c) = host_data.config_json.as_ref() {
+        // fall back to the safe default if the JSON is bad
+        let config: ConnectionConfig = match serde_json::from_str(c) {
+            Ok(c) => c,
+            Err(e) => {
+                error!("Failed to parse host data config JSON: {e:?}");
+                ConnectionConfig::default()
+            }
+        };
+        NatsMessagingProvider {
+            default_config: config,
+            ..Default::default()
+        }
+    } else {
+        NatsMessagingProvider::default()
+    };
+    provider_main(provider, Some("Nats Messaging Provider".to_string()))?;
 
     eprintln!("Nats-messaging provider exiting");
     Ok(())
@@ -34,7 +48,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
 /// Configuration for connecting a nats client.
 /// More options are available if you use the json than variables in the values string map.
-#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 struct ConnectionConfig {
     /// list of topics to subscribe to
     #[serde(default)]
@@ -49,6 +63,18 @@ struct ConnectionConfig {
     /// ping interval in seconds
     #[serde(default)]
     ping_interval_sec: Option<u16>,
+}
+
+impl Default for ConnectionConfig {
+    fn default() -> ConnectionConfig {
+        ConnectionConfig {
+            subscriptions: vec![],
+            cluster_uris: vec!["nats://127.0.0.1:4222".to_string()],
+            auth_jwt: None,
+            auth_seed: None,
+            ping_interval_sec: None,
+        }
+    }
 }
 
 impl ConnectionConfig {
@@ -97,7 +123,9 @@ impl ConnectionConfig {
 struct NatsMessagingProvider {
     // store nats connection client per actor
     actors: Arc<RwLock<HashMap<String, async_nats::Client>>>,
+    default_config: ConnectionConfig,
 }
+
 // use default implementations of provider message handlers
 impl ProviderDispatch for NatsMessagingProvider {}
 
@@ -216,7 +244,12 @@ impl ProviderHandler for NatsMessagingProvider {
     /// If the link is allowed, return true, otherwise return false to deny the link.
     #[instrument(level = "debug", skip(self, ld), fields(actor_id = %ld.actor_id))]
     async fn put_link(&self, ld: &LinkDefinition) -> RpcResult<bool> {
-        let config = ConnectionConfig::new_from(&ld.values)?;
+        // If the link definition values are empty, use the default connection configuration
+        let config = if ld.values.is_empty() {
+            self.default_config.clone()
+        } else {
+            ConnectionConfig::new_from(&ld.values)?
+        };
         let conn = self.connect(config, ld).await?;
 
         let mut update_map = self.actors.write().await;
@@ -308,5 +341,29 @@ impl Messaging for NatsMessagingProvider {
                 subject: resp.subject,
             }),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::ConnectionConfig;
+
+    #[test]
+    fn test_default_connection_serialize() {
+        // test to verify that we can default a config with partial input
+        let input = r#"
+{
+    "cluster_uris": ["nats://soyvuh"],
+    "auth_jwt": "authy",
+    "auth_seed": "seedy"
+}        
+"#;
+
+        let config: ConnectionConfig = serde_json::from_str(&input).unwrap();
+        assert_eq!(config.auth_jwt.unwrap(), "authy");
+        assert_eq!(config.auth_seed.unwrap(), "seedy");
+        assert_eq!(config.cluster_uris, ["nats://soyvuh"]);
+        assert!(config.subscriptions.is_empty());
+        assert!(config.ping_interval_sec.is_none());
     }
 }


### PR DESCRIPTION
# Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Unlike many of the other capability providers, this one didn't support the notion of supplying a single default connection configuration for all linked actors, which in turn allows actors to be linked w/out values for convenience.

# Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
None

# Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->
Next release, currently planning on it being 0.15.1 as this is not a breaking change

# Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
If consumers were to accidentally leave connection data blank on link definitions, then instead of crashing this new version of the provider will attempt anonymous localhost connection to the NATS server.

# Testing
<!---
Declare the testing information for this pull request
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

## Platforms
<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [X] aarch64-darwin
- [ ] x86_64-windows

## Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->
Added unit test to verify that the connection configuration supplied via the start configuration doesn't need all of the fields. 

## Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->
No automated acceptance tests

## Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
Added a unit test that verifies that the connection information can be properly deserialized from partial data supplied via JSON in the start provider request. Also manually used `iex` to load this new provider with host configuration and w/out to verify that it could accept the start parameters.
