### PR TITLE
Fixing the host configuration parser

### DIFF
--- a/nats/Cargo.lock
+++ b/nats/Cargo.lock
@@ -2875,7 +2875,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-nats"
-version = "0.16.0"
+version = "0.16.1"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-nats"
-version = "0.16.0"
+version = "0.16.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# Feature or Problem
<!---
Briefly describe the reason for this pull request: the feature being added or problem being solved.
--->
Previous version would fail if the host_data.config_json was `Some("")`

# Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->
n/a

# Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->
n/a

# Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->
Fixes a bug where 0.16.0 was basically unusable without supplying host configuration

# Testing
<!---
Declare the testing information for this pull request
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [X] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows


## Platforms
<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [X] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

## Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->
Added unit tests to cover new rules for config ingestion

## Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->
none

## Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
started host locally
