### PR TITLE
release(nats): v0.17.0

### DIFF
--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-nats"
-version = "0.16.1"
+version = "0.17.0"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
# Feature or Problem

Release nats provider `v0.17.0`

# Related Issues

https://github.com/wasmCloud/capability-providers/pull/205

# Release Information

`v0.17.0`

# Consumer Impact

Customers using NATS capability providers will have subscriptions properly flushed when links are removed.

# Testing

Run the integration/E2E tests as normal

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [x] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

## Unit Test(s)

No new Unit tests were added

## Acceptance or Integration

Integration test suite was augmented with a test for that *approximately* tests that the drops are performed.

## Manual Verification

Manually verified
