### PR TITLE
Ensure we flush on message publish

### DIFF
--- a/nats/Cargo.lock
+++ b/nats/Cargo.lock
@@ -2858,6 +2858,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasmcloud-interface-testing"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07cda5358bdc6d7739a8510aa5ea264d3930b239ffdd6eee8c39fbae2577dd76"
+dependencies = [
+ "async-trait",
+ "regex",
+ "rmp-serde",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "wasmbus-rpc",
+ "weld-codegen 0.5.0",
+]
+
+[[package]]
 name = "wasmcloud-provider-nats"
 version = "0.16.3"
 dependencies = [
@@ -2884,6 +2900,30 @@ dependencies = [
  "wascap",
  "wasmbus-rpc",
  "wasmcloud-interface-messaging",
+ "wasmcloud-test-util",
+]
+
+[[package]]
+name = "wasmcloud-test-util"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e61ffa428b4c302c24802180cd406039c632091dcd9c0952ffa4d9283b0e55b8"
+dependencies = [
+ "anyhow",
+ "async-nats",
+ "async-trait",
+ "base64",
+ "futures",
+ "log",
+ "nkeys",
+ "regex",
+ "serde",
+ "serde_json",
+ "termcolor",
+ "tokio",
+ "toml",
+ "wasmbus-rpc",
+ "wasmcloud-interface-testing",
 ]
 
 [[package]]

--- a/nats/Cargo.lock
+++ b/nats/Cargo.lock
@@ -2858,24 +2858,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmcloud-interface-testing"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07cda5358bdc6d7739a8510aa5ea264d3930b239ffdd6eee8c39fbae2577dd76"
-dependencies = [
- "async-trait",
- "regex",
- "rmp-serde",
- "serde",
- "serde_bytes",
- "serde_json",
- "wasmbus-rpc",
- "weld-codegen 0.5.0",
-]
-
-[[package]]
 name = "wasmcloud-provider-nats"
-version = "0.16.2"
+version = "0.16.3"
 dependencies = [
  "anyhow",
  "async-nats",
@@ -2900,30 +2884,6 @@ dependencies = [
  "wascap",
  "wasmbus-rpc",
  "wasmcloud-interface-messaging",
- "wasmcloud-test-util",
-]
-
-[[package]]
-name = "wasmcloud-test-util"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e61ffa428b4c302c24802180cd406039c632091dcd9c0952ffa4d9283b0e55b8"
-dependencies = [
- "anyhow",
- "async-nats",
- "async-trait",
- "base64",
- "futures",
- "log",
- "nkeys",
- "regex",
- "serde",
- "serde_json",
- "termcolor",
- "tokio",
- "toml",
- "wasmbus-rpc",
- "wasmcloud-interface-testing",
 ]
 
 [[package]]

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "wasmcloud-provider-nats"
-version = "0.16.2"
+version = "0.16.3"
 edition = "2021"
 
 [dependencies]
-async-nats = "0.23"
+async-nats = "0.23.0"
 async-trait = "0.1"
 atty = "0.2"
 base64 = "0.13"
@@ -26,12 +26,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wascap = "0.8.0"
 anyhow = "1.0.69"
 
-wasmbus-rpc = { version = "0.11.2", features = [ "otel" ] }
-wasmcloud-interface-messaging = "0.8.1"
+wasmbus-rpc = { version = "0.11.2", features = ["otel"] }
+wasmcloud-interface-messaging = "0.8.0"
 
 # test dependencies
-[dev-dependencies]
-wasmcloud-test-util = "0.6.4"
+# [dev-dependencies]
+# wasmcloud-test-util = "0.6.4"
 
 [[bin]]
 name = "nats_messaging"

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.16.3"
 edition = "2021"
 
 [dependencies]
-async-nats = "0.23.0"
+async-nats = "0.23"
 async-trait = "0.1"
 atty = "0.2"
 base64 = "0.13"
@@ -26,12 +26,12 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 wascap = "0.8.0"
 anyhow = "1.0.69"
 
-wasmbus-rpc = { version = "0.11.2", features = ["otel"] }
-wasmcloud-interface-messaging = "0.8.0"
+wasmbus-rpc = { version = "0.11.2", features = [ "otel" ] }
+wasmcloud-interface-messaging = "0.8.1"
 
 # test dependencies
-# [dev-dependencies]
-# wasmcloud-test-util = "0.6.4"
+[dev-dependencies]
+wasmcloud-test-util = "0.6.4"
 
 [[bin]]
 name = "nats_messaging"


### PR DESCRIPTION
## Feature or Problem
Fixes an issue where we didn't flush after message publishes in this provider like we do during provider invocations in `wasmbus-rpc`

## Related Issues
None

## Release Information
`v0.16.3`

## Consumer Impact
Consumers using this provider will notice their publishes going through immediately instead of after a few (sometimes up to 40) millisecond delay

## Testing
I ran through this locally with some traces to confirm that flushing improves performance.

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Manual Verification
As detailed above, I manually verified this worked. Additionally, this is the same fix that we implemented in wasmbus-rpc a few months back, so we know it works well
