### PR TITLE
add metadata to Cargo.toml for publishing to crates.io, use consistent naming for crate

### DIFF
--- a/httpserver-rs/Cargo.lock
+++ b/httpserver-rs/Cargo.lock
@@ -127,13 +127,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.67"
+version = "0.1.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86ea188f25f0255d8f92797797c97ebf5631fa88178beb1a46fdf5622c9a00e4"
+checksum = "b9ccdd8f2a161be9bd5c023df56f1b2a0bd1d83872ae53b71a84a12c9bf6e842"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.9",
 ]
 
 [[package]]
@@ -352,7 +352,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.9",
 ]
 
 [[package]]
@@ -1331,9 +1331,9 @@ checksum = "624a8340c38c1b80fd549087862da4ba43e08858af025b236e509b6649fc13d5"
 
 [[package]]
 name = "openssl"
-version = "0.10.47"
+version = "0.10.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8b277f87dacc05a6b709965d1cbafac4649d6ce9f3ce9ceb88508b5666dfec9"
+checksum = "518915b97df115dd36109bfa429a48b8f737bd05508cf9588977b599648926d2"
 dependencies = [
  "bitflags",
  "cfg-if",
@@ -1363,9 +1363,9 @@ checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.82"
+version = "0.9.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a95792af3c4e0153c3914df2261bedd30a98476f94dc892b67dfe1d89d433a04"
+checksum = "666416d899cf077260dac8698d60a60b435a46d57e82acb1be3d0dad87284e5b"
 dependencies = [
  "autocfg",
  "cc",
@@ -2107,7 +2107,7 @@ checksum = "e801c1712f48475582b7696ac71e0ca34ebb30e09338425384269d9717c62cad"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.9",
 ]
 
 [[package]]
@@ -2138,7 +2138,7 @@ checksum = "bcec881020c684085e55a25f7fd888954d56609ef363479dc5a1305eb0d40cab"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.9",
 ]
 
 [[package]]
@@ -2344,9 +2344,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.8"
+version = "2.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc02725fd69ab9f26eab07fad303e2497fad6fb9eba4f96c4d1687bdf704ad9"
+checksum = "0da4a3c17e109f700685ec577c0f85efd9b19bcf15c913985f14dc1ac01775aa"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2404,7 +2404,7 @@ checksum = "f9456a42c5b0d803c8cd86e73dd7cc9edd429499f37a3550d286d5e86720569f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.8",
+ "syn 2.0.9",
 ]
 
 [[package]]
@@ -3128,7 +3128,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasmcloud-provider-httpserver"
+name = "wasmcloud-httpserver-provider"
 version = "0.17.1"
 dependencies = [
  "assert_matches",
@@ -3364,9 +3364,9 @@ checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "winnow"
-version = "0.4.0"
+version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "deac0939bd6e4f24ab5919fbf751c97a8cfc8543bb083a305ed5c0c10bb241d1"
+checksum = "ae8970b36c66498d8ff1d66685dc86b91b29db0c7739899012f63a63814b4b28"
 dependencies = [
  "memchr",
 ]

--- a/httpserver-rs/Cargo.toml
+++ b/httpserver-rs/Cargo.toml
@@ -1,5 +1,8 @@
 [package]
-name = "wasmcloud-provider-httpserver"
+name = "wasmcloud-httpserver-provider"
+description = "implementation of http server for wasmcloud, using warp"
+license = "Apache-2.0"
+authors = ["wasmCloud Team"]
 version = "0.17.1"
 edition = "2021"
 
@@ -32,7 +35,7 @@ reqwest = { version = "0.11", features = ["json"]}
 wasmcloud-test-util = "0.7.0"
 
 [lib]
-name = "wasmcloud_provider_httpserver"
+name = "wasmcloud_httpserver_provider"
 path = "src/lib.rs"
 
 [[bin]]

--- a/httpserver-rs/bin/main.rs
+++ b/httpserver-rs/bin/main.rs
@@ -8,7 +8,7 @@ use tracing::{error, instrument, trace, warn};
 use wasmbus_rpc::{
     core::LinkDefinition, error::RpcError, provider::prelude::*, provider::ProviderTransport,
 };
-use wasmcloud_provider_httpserver::{
+use wasmcloud_httpserver_provider::{
     load_settings,
     wasmcloud_interface_httpserver::{HttpRequest, HttpResponse, HttpServer, HttpServerSender},
     HttpServerCore,

--- a/httpserver-rs/src/lib.rs
+++ b/httpserver-rs/src/lib.rs
@@ -103,7 +103,7 @@ pub struct Inner {
 
 /// An asynchronous HttpServer with support for CORS and TLS
 /// ```no_test
-///   use wasmcloud_provider_httpserver::{HttpServer, load_settings};
+///   use wasmcloud_httpserver_provider::{HttpServer, load_settings};
 ///   let settings = load_settings(ld.values)?;
 ///   let server = HttpServer::new(settings);
 ///   let task = server.serve()?;
@@ -159,7 +159,7 @@ impl HttpServerCore {
 
     /// Start the server in a new thread
     /// ```no_test
-    ///    use wasmcloud_provider_httpserver::{HttpServer, load_settings};
+    ///    use wasmcloud_httpserver_provider::{HttpServer, load_settings};
     ///    let settings = load_settings(&ld.values)?;
     ///    let server = HttpServer::new(settings);
     ///    let _ = server.start().await?;

--- a/httpserver-rs/tests/httpserver_test.rs
+++ b/httpserver-rs/tests/httpserver_test.rs
@@ -17,7 +17,7 @@
 //!
 use std::time::Instant;
 use wasmbus_rpc::{core::InvocationResponse, provider::prelude::*};
-use wasmcloud_provider_httpserver::wasmcloud_interface_httpserver::{HttpRequest, HttpResponse};
+use wasmcloud_httpserver_provider::wasmcloud_interface_httpserver::{HttpRequest, HttpResponse};
 use wasmcloud_test_util::{
     check, cli::print_test_results, provider_test::test_provider, run_selected_spawn,
     testing::TestOptions,


### PR DESCRIPTION
add metadata to Cargo.toml for publishing to crates.io, use consistent naming for crate

## Feature or Problem
1. to publish to crates.io, need to add description and license fields to Cargo.toml metadata
2. gh workflow was looking for tag 'wasmcloud-httpserver-provider' but crate name was going to be 'wasmcloud-provider-httpserver'. Changed all to 'wasmcloud-httpserver-provider' for consistentcy. Doesn't affect httpserver provider builds 

## Release Information

creates wasmcloud-httpserver-provider-0.1.0 

## Consumer Impact
n/a

## Testing
tests pass

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
in tests/*.rs
pass

### Acceptance or Integration
n/a

### Manual Verification
n/a
