### PR TITLE
kvredis: Switch to using rustls

### DIFF
--- a/kvredis/Cargo.lock
+++ b/kvredis/Cargo.lock
@@ -1718,9 +1718,9 @@ dependencies = [
 
 [[package]]
 name = "redis"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513b3649f1a111c17954296e4a3b9eecb108b766c803e2b99f179ebe27005985"
+checksum = "3ea8c51b5dc1d8e5fd3350ec8167f464ec0995e79f2e90a075b63371500d557f"
 dependencies = [
  "arc-swap",
  "async-trait",
@@ -1731,6 +1731,7 @@ dependencies = [
  "itoa",
  "percent-encoding",
  "pin-project-lite",
+ "rustls 0.21.0",
  "ryu",
  "sha1_smol",
  "tokio",

--- a/kvredis/Cargo.toml
+++ b/kvredis/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-kvredis"
-version = "0.20.0"
+version = "0.21.0"
 edition = "2021"
 
 [dependencies]
@@ -12,7 +12,7 @@ chrono = "0.4"
 crossbeam = "0.8"
 futures = "0.3"
 once_cell = "1.8"
-redis = { version = "0.22.1", features = ["tokio-comp", "aio", "connection-manager"] }
+redis = { version = "0.23.0", features = ["tokio-comp", "aio", "connection-manager", "rustls"] }
 rmp-serde = "1.1.0"
 serde_bytes = "0.11"
 serde_json = "1.0"


### PR DESCRIPTION
## Feature or Problem
It looks like older versions of the `redis` crate implicitly linked to OpenSSL. The latest version of the crate supports `rustls` which we use in every other capability provider, so we should use that instead.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
next

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
