### PR TITLE
fix(blobstore): Fixes path canonicalization

### DIFF
--- a/blobstore-fs/Cargo.lock
+++ b/blobstore-fs/Cargo.lock
@@ -1295,6 +1295,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
 
 [[package]]
+name = "path-clean"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17359afc20d7ab31fdb42bb844c8b3bb1dabd7dcf7e68428492da7f16966fcef"
+
+[[package]]
 name = "pem-rfc7468"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2749,12 +2755,13 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "async-trait",
  "atty",
  "base64 0.13.1",
  "futures-util",
+ "path-clean",
  "serde",
  "serde_json",
  "tokio",

--- a/blobstore-fs/Cargo.toml
+++ b/blobstore-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 resolver = "2"
 
@@ -8,6 +8,7 @@ resolver = "2"
 async-trait = "0.1"
 atty = "0.2"
 base64 = "0.13"
+path-clean = "1"
 serde = "1.0"
 serde_json = "1.0"
 tokio = "1.17.0"

--- a/blobstore-fs/Makefile
+++ b/blobstore-fs/Makefile
@@ -16,7 +16,7 @@ include ../build/makefiles/provider.mk
 ifeq ($(shell nc -zt -w1 127.0.0.1 4222 || echo fail),fail)
 test::
 	@killall blobstore_fs || true
-	docker run --rm -d --name fs-provider-test -p 127.0.0.1:4222:4222 nats:2.8.4-alpine -js
+	docker run --rm -d --name fs-provider-test -p 127.0.0.1:4222:4222 nats:2.9.16-alpine -js
 	RUST_BACKTRACE=1 RUST_LOG=debug cargo test $(TEST_FLAGS)
 	docker stop fs-provider-test
 else


### PR DESCRIPTION
## Feature or Problem
The `canonicalize` method requires that the path actually exists, which was causing problems. This uses a handy crate that does the same path cleaning as Go does. I also fixed a bunch of clippy lints we had

## Release Information
Blobstore FS 0.3.1

## Consumer Impact
Right now this provider doesn't work, so now it will work

## Testing

All tests pass and I ran through a full example using blobby

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)

None, current tests now pass
