### PR TITLE
Fix/provider releases

### DIFF
--- a/.github/workflows/blobstore-s3.yml
+++ b/.github/workflows/blobstore-s3.yml
@@ -104,6 +104,7 @@ jobs:
 
       - name: Build native executable
         run: |
+          mkdir -p ${HOME}/.cache
           chmod +x ~/.cargo/bin/cross
           XDG_CACHE_HOME=${HOME}/.cache cross build --release --target ${{ matrix.target }}
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -69,8 +69,9 @@ jobs:
 
       - name: Build native executable
         run: |
+          mkdir -p ${HOME}/.cache
           chmod +x ~/.cargo/bin/cross
-          cross build --release --target ${{ matrix.target }}
+          XDG_CACHE_HOME=${HOME}/.cache cross build --release --target ${{ matrix.target }}
         working-directory: ${{ env.working-directory }}
 
       - name: Upload executable to GH Actions

--- a/httpserver-rs/Cross.toml
+++ b/httpserver-rs/Cross.toml
@@ -1,3 +1,7 @@
+[build.env]
+volumes = ["XDG_CACHE_HOME"]
+passthrough = ["XDG_CACHE_HOME"]
+
 [target.armv7-unknown-linux-gnueabihf]
 image = "wasmcloud/cross:armv7-unknown-linux-gnueabihf"
 


### PR DESCRIPTION
- `blobstore-s3` was missing a step to ensure `XDG_CACHE_HOME` (`${HOME}/.cache`) exists
- `httpserver-rs` was missing cross config for `XDG_CACHE_HOME`