### PR TITLE
Httpserver readonly mode

### DIFF
--- a/httpserver-rs/settings.md
+++ b/httpserver-rs/settings.md
@@ -27,7 +27,7 @@ An empty tls section, or no tls section, disables tls. To enable TLS, both `cert
 - `allowed_headers` - a list of allowed headers, case-insensitive. See [`Access-Control-Allow-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Allow-Headers) Default:
 
   ```json
-  ["accept", "accept-language", "content-type", "content-language"]
+  ["accept", "accept-language", "content-type", "content-language","cache-control"]
   ```
 
 - `exposed_headers` - see [`Access-Control-Expose-Headers`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Access-Control-Expose-Headers)
@@ -63,7 +63,7 @@ Example with all settings
   "cors": {
     "allowed_origins": [],
     "allowed_headers": [
-      "accept", "accept-language", "content-language", "content-type", "x-custome-header"
+      "accept", "accept-language", "content-language", "content-type", "cache-control","x-custome-header"
     ],
     "allowed_methods": [ "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS" ],
     "exposed_headers": [],

--- a/httpserver-rs/src/lib.rs
+++ b/httpserver-rs/src/lib.rs
@@ -192,6 +192,19 @@ impl HttpServerCore {
                     let ld = linkdefs.clone();
                     let arc_inner = arc_inner.clone();
                     async move {
+                        if let Some(mode) = ld.values.get("READONLY_MODE"){
+                            match mode.parse() {
+                                Ok(true) => {
+                                    if method!= http::method::Method::GET || method!= http::method::Method::HEAD{
+                                        panic!("Cannot use other methods in Read Only Mode");
+                                    }
+                                }
+                                Ok(false) =>(),
+                                Err(e) =>{
+                                    error!("Invalid bool value : {:?}",e);
+                                }
+                            }
+                        };
                         let hmap = convert_request_headers(&headers);
                         let req = HttpRequest {
                             body: Vec::from(body),

--- a/httpserver-rs/src/settings.rs
+++ b/httpserver-rs/src/settings.rs
@@ -194,7 +194,7 @@ impl ServiceSettings {
         if let Some(cache_control) = self.cache_control.as_ref() {
             for val in cache_control.iter() {
                 if http::HeaderValue::from_str(val).is_err() {
-                    errors.push("Invalid Cache Control header".to_string());
+                    errors.push(format!("Invalid Cache Control header : '{}'", val));
                 }
             }
         }

--- a/httpserver-rs/src/settings.rs
+++ b/httpserver-rs/src/settings.rs
@@ -33,6 +33,7 @@ const CORS_ALLOWED_HEADERS: &[&str] = &[
     "accept-language",
     "content-type",
     "content-language",
+    "cache-control",
 ];
 const CORS_EXPOSED_HEADERS: &[&str] = &[];
 const CORS_DEFAULT_MAX_AGE_SECS: u64 = 300;
@@ -68,6 +69,9 @@ pub struct ServiceSettings {
     #[serde(default)]
     pub timeout_ms: Option<u64>,
 
+    /// cache control options
+    pub cache_control: Option<Vec<String>>,
+
     /// Max content length. Default "10m" (10MiB = 10485760 bytes)
     /// Can be overridden by link def value max_content_len
     /// Accepts number (bytes), or number with suffix 'k', 'm', or 'g', (upper or lower case)
@@ -92,6 +96,7 @@ impl Default for ServiceSettings {
             cors: Cors::default(),
             log: Log::default(),
             timeout_ms: None,
+            cache_control: None,
             max_content_len: Some(DEFAULT_MAX_CONTENT_LEN.to_string()),
             extra: Default::default(),
         }
@@ -141,7 +146,7 @@ impl ServiceSettings {
 
     /// Merge settings from other into self
     fn merge(&mut self, other: ServiceSettings) {
-        merge!(self, other, address);
+        merge!(self, other, address, cache_control);
         self.tls.merge(other.tls);
         self.cors.merge(other.cors);
         self.log.merge(other.log);
@@ -186,6 +191,13 @@ impl ServiceSettings {
                 }
             }
         }
+        if let Some(cache_control) = self.cache_control.as_ref() {
+            for val in cache_control.iter() {
+                if http::HeaderValue::from_str(val).is_err() {
+                    errors.push("Invalid Cache Control header".to_string());
+                }
+            }
+        }
         if !errors.is_empty() {
             Err(Error::Settings(format!(
                 "\nInvalid httpserver settings: \n{}\n",
@@ -209,7 +221,7 @@ impl ServiceSettings {
 pub fn load_settings(values: &HashMap<String, String>) -> Result<ServiceSettings, Error> {
     // Allow keys to be UPPERCASE, as an accommodation
     // for the lost souls who prefer ugly all-caps variable names.
-    let values = crate::make_case_insensitive(values).ok_or_else(|| Error::InvalidParameter(
+    let values: HashMap<String, &String> = crate::make_case_insensitive(values).ok_or_else(|| Error::InvalidParameter(
         "Key collision: httpserver settings (from linkdef.values) has one or more keys that are not unique based on case-insensitivity"
             .to_string(),
     ))?;
@@ -250,6 +262,16 @@ pub fn load_settings(values: &HashMap<String, String>) -> Result<ServiceSettings
             IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
             port,
         ));
+    }
+
+    // accept cache-control header values
+    if let Some(cache_control) = values.get("cache_control") {
+        settings.cache_control = Some(
+            cache_control
+                .split(',')
+                .map(|s| s.trim().to_owned())
+                .collect(),
+        );
     }
 
     settings.validate()?;


### PR DESCRIPTION
## Feature or Problem
The http server capability provider accepts a value on the linkef named "READONLY_MODE" that accepts boolean values. If this flag is set to true, only GET and HEAD methods are permitted.

## Related Issues
#237 

## Release Information
Next

## Consumer Impact
Additional feature. No significant impact on existing users.

## Testing
Manual testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
NA

### Acceptance or Integration
NA

### Manual Verification
Manually tested