### PR TITLE
Bumped httpserver to 0.18.2 for release

### DIFF
--- a/httpserver-rs/Cargo.lock
+++ b/httpserver-rs/Cargo.lock
@@ -3153,7 +3153,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-httpserver"
-version = "0.18.1"
+version = "0.18.2"
 dependencies = [
  "assert_matches",
  "async-trait",

--- a/httpserver-rs/Cargo.toml
+++ b/httpserver-rs/Cargo.toml
@@ -3,7 +3,7 @@ name = "wasmcloud-provider-httpserver"
 description = "Http server for wasmcloud, using warp. This package provides a library, and a capability provider with the 'wasmcloud:httpserver' contract."
 license = "Apache-2.0"
 authors = ["wasmCloud Team"]
-version = "0.18.1"
+version = "0.18.2"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
Releasing https://github.com/wasmCloud/capability-providers/pull/240