### PR TITLE
Added readonly mode to httpserver

### DIFF
--- a/httpserver-rs/settings.md
+++ b/httpserver-rs/settings.md
@@ -78,8 +78,8 @@ Example with all settings
     "max_age_secs": 300
   },
   "max_content_len": "100M",
-  "cache-control": "max-age=20",
-  "readonly-mode": false,
+  "cache_control": "max-age=20",
+  "readonly_mode": false,
 }
 ```
 
@@ -96,5 +96,3 @@ The link definition connecting an actor to a capability provider includes a key-
   (The option `-w0` omits line breaks within the base64)
 
 - use key `config_json`, with a value that is the raw json. Don't forget to escape quotes.
-
-- use key `readonly_mode`, with a boolean value to set the mode as true or false.

--- a/httpserver-rs/settings.md
+++ b/httpserver-rs/settings.md
@@ -47,6 +47,10 @@ For example, the following setting limits uploads to 20 MB.
 
 An optional set of cache-control values that will appear in the header if they are not already set.
 
+### Read Only Mode
+
+If set to true, it allows only GET and HEAD methods on the provider. Default value is false.
+
 ## Examples of settings files
 
 Bind to all IP interfaces and port 3000, with TLS disabled
@@ -74,7 +78,8 @@ Example with all settings
     "max_age_secs": 300
   },
   "max_content_len": "100M",
-  "cache-control":"max-age=20"
+  "cache-control": "max-age=20",
+  "readonly-mode": false,
 }
 ```
 
@@ -91,3 +96,5 @@ The link definition connecting an actor to a capability provider includes a key-
   (The option `-w0` omits line breaks within the base64)
 
 - use key `config_json`, with a value that is the raw json. Don't forget to escape quotes.
+
+- use key `readonly_mode`, with a boolean value to set the mode as true or false.

--- a/httpserver-rs/src/lib.rs
+++ b/httpserver-rs/src/lib.rs
@@ -192,8 +192,7 @@ impl HttpServerCore {
                     let ld = linkdefs.clone();
                     let arc_inner = arc_inner.clone();
                     async move{
-                        if let Some(mode) = ld.values.get("READONLY_MODE"){
-                            let readonly_mode =  mode.parse().unwrap_or(false);
+                        if let Some(readonly_mode) = arc_inner.settings.readonly_mode{
                             if readonly_mode && method!= http::method::Method::GET && method!= http::method::Method::HEAD {
                                 debug!("Cannot use other methods in Read Only Mode");
                                 // If this fails it is developer error, so unwrap is okay

--- a/httpserver-rs/src/lib.rs
+++ b/httpserver-rs/src/lib.rs
@@ -44,7 +44,7 @@ use futures::Future;
 use http::header::HeaderMap;
 use thiserror::Error as ThisError;
 use tokio::task::JoinHandle;
-use tracing::{error, info, trace, Instrument};
+use tracing::{debug, error, info, trace, Instrument};
 use warp::{filters::cors::Builder, path::FullPath, Filter};
 use wasmbus_rpc::{core::LinkDefinition, error::RpcResult};
 use wasmcloud_interface_httpserver::{HttpRequest, HttpResponse};
@@ -191,7 +191,16 @@ impl HttpServerCore {
                     let span = tracing::debug_span!("http request", %method, path = %path.as_str(), %query);
                     let ld = linkdefs.clone();
                     let arc_inner = arc_inner.clone();
-                    async move {
+                    async move{
+                        if let Some(mode) = ld.values.get("READONLY_MODE"){
+                            let readonly_mode =  mode.parse().unwrap_or(false);
+                            if readonly_mode && method!= http::method::Method::GET && method!= http::method::Method::HEAD {
+                                debug!("Cannot use other methods in Read Only Mode");
+                                // If this fails it is developer error, so unwrap is okay
+                                let resp = http::Response::builder().status(http::StatusCode::METHOD_NOT_ALLOWED).body(Vec::with_capacity(0)).unwrap();
+                                return Ok::<_, warp::Rejection>(resp)
+                            }
+                        }
                         let hmap = convert_request_headers(&headers);
                         let req = HttpRequest {
                             body: Vec::from(body),

--- a/httpserver-rs/src/settings.rs
+++ b/httpserver-rs/src/settings.rs
@@ -71,6 +71,9 @@ pub struct ServiceSettings {
     /// cache control options
     pub cache_control: Option<String>,
 
+    /// Flag for read only mode
+    pub readonly_mode: Option<bool>,
+
     /// Max content length. Default "10m" (10MiB = 10485760 bytes)
     /// Can be overridden by link def value max_content_len
     /// Accepts number (bytes), or number with suffix 'k', 'm', or 'g', (upper or lower case)
@@ -96,6 +99,7 @@ impl Default for ServiceSettings {
             log: Log::default(),
             timeout_ms: None,
             cache_control: None,
+            readonly_mode: Some(false),
             max_content_len: Some(DEFAULT_MAX_CONTENT_LEN.to_string()),
             extra: Default::default(),
         }
@@ -145,7 +149,7 @@ impl ServiceSettings {
 
     /// Merge settings from other into self
     fn merge(&mut self, other: ServiceSettings) {
-        merge!(self, other, address, cache_control);
+        merge!(self, other, address, cache_control, readonly_mode);
         self.tls.merge(other.tls);
         self.cors.merge(other.cors);
         self.log.merge(other.log);
@@ -267,6 +271,11 @@ pub fn load_settings(values: &HashMap<String, String>) -> Result<ServiceSettings
     // accept cache-control header values
     if let Some(cache_control) = values.get("cache_control") {
         settings.cache_control = Some(cache_control.to_string());
+    }
+
+    // accept read only mode flag
+    if let Some(readonly_mode) = values.get("readonly_mode") {
+        settings.readonly_mode = Some(readonly_mode.to_string().parse().unwrap_or(false));
     }
 
     settings.validate()?;


### PR DESCRIPTION
## Feature or Problem
The http server capability provider accepts a value on the linkef named "READONLY_MODE" that accepts boolean values. If this flag is set to true, only GET and HEAD methods are permitted.

## Related Issues
#237 

## Release Information
Next

## Consumer Impact
Additional feature. No significant impact on existing users.

## Testing
Manual testing

Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows


Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
NA

### Acceptance or Integration
NA

### Manual Verification
Manually verified.