### PR TITLE
fix: Blobstore FS and S3 provider fixes

### DIFF
--- a/blobstore-fs/Cargo.lock
+++ b/blobstore-fs/Cargo.lock
@@ -2866,7 +2866,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "atty",

--- a/blobstore-fs/Cargo.toml
+++ b/blobstore-fs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-fs"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 resolver = "2"
 

--- a/blobstore-fs/src/fs_utils.rs
+++ b/blobstore-fs/src/fs_utils.rs
@@ -3,7 +3,10 @@ use std::vec::Vec;
 
 /// Traverses a file system starting at location `root` and returning a list of all directories
 /// contained in that directory, recursively, relative to the original root at level 0.
-pub fn all_dirs(root: &Path, prefix: &Path) -> Vec<PathBuf> {
+pub fn all_dirs(root: &Path, prefix: &Path, depth: u32) -> Vec<PathBuf> {
+    if depth > 1000 {
+        return vec![];
+    }
     let mut dirs: Vec<PathBuf> = match std::fs::read_dir(root) {
         Ok(rd) => rd
             .filter(|e| match e {
@@ -23,7 +26,7 @@ pub fn all_dirs(root: &Path, prefix: &Path) -> Vec<PathBuf> {
     // Now recursively go in all directories and collect all sub-directories
     let mut subdirs: Vec<PathBuf> = Vec::new();
     for dir in &dirs {
-        let mut local_subdirs = all_dirs(prefix.join(dir.as_path()).as_path(), prefix);
+        let mut local_subdirs = all_dirs(prefix.join(dir.as_path()).as_path(), prefix, depth + 1);
         subdirs.append(&mut local_subdirs);
     }
     dirs.append(&mut subdirs);
@@ -54,7 +57,7 @@ mod tests {
             );
         }
 
-        let dirs = all_dirs(root, root);
+        let dirs = all_dirs(root, root, 0);
 
         clear_state(root);
 
@@ -72,7 +75,7 @@ mod tests {
             panic!("Error in create_dir_all: {}", e);
         }
 
-        let dirs = all_dirs(root, root);
+        let dirs = all_dirs(root, root, 0);
 
         clear_state(root);
 
@@ -94,7 +97,7 @@ mod tests {
 
         File::create(root.join("dir2/foo.txt").as_path()).unwrap();
 
-        let dirs = all_dirs(root, root);
+        let dirs = all_dirs(root, root, 0);
 
         clear_state(root);
 

--- a/blobstore-fs/src/main.rs
+++ b/blobstore-fs/src/main.rs
@@ -378,7 +378,7 @@ impl Blobstore for FsProvider {
     async fn list_containers(&self, ctx: &Context) -> RpcResult<ContainersInfo> {
         let root = self.get_root(ctx).await?;
 
-        let containers = all_dirs(&root, &root)
+        let containers = all_dirs(&root, &root, 0)
             .iter()
             .map(|c| ContainerMetadata {
                 container_id: c.as_path().display().to_string(),

--- a/blobstore-s3/Cargo.lock
+++ b/blobstore-s3/Cargo.lock
@@ -3324,7 +3324,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "async-trait",
  "atty",

--- a/blobstore-s3/Cargo.toml
+++ b/blobstore-s3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-blobstore-s3"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]


### PR DESCRIPTION
## Feature or Problem
This PR fixes two possible low severity issues in the blobstore providers. In the FS provider we're preventing infinite filesystem recursion, and in the S3 provider we're preventing an infinite loop when an actor send back invalid responses for `send_chunk`.

## Related Issues
N/A

## Release Information
blobstore-fs 0.5.1
blobstore-s3 0.5.1

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
