### PR TITLE
[FEAT] Renew vault token if possible

### DIFF
--- a/kv-vault/.gitignore
+++ b/kv-vault/.gitignore
@@ -1,3 +1,6 @@
 build
 target
 .idea
+
+# Ignore test created environment files
+*.env

--- a/kv-vault/Cargo.lock
+++ b/kv-vault/Cargo.lock
@@ -2195,6 +2195,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74233d3b3b2f6d4b006dc19dee745e73e2a6bfb6f93607cd3b02bd5b00797d7c"
 
 [[package]]
+name = "simple_env_load"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "062f063a8bb8336fa98ee0eae53115bf6753ca9c83437808bf000c65621ca5e3"
+
+[[package]]
 name = "slab"
 version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3026,6 +3032,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_json",
+ "simple_env_load",
  "thiserror",
  "tokio",
  "tracing",

--- a/kv-vault/Cargo.lock
+++ b/kv-vault/Cargo.lock
@@ -3018,7 +3018,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-kv-vault"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "atty",

--- a/kv-vault/Cargo.toml
+++ b/kv-vault/Cargo.toml
@@ -21,6 +21,7 @@ url = "2.2.2"
 vaultrs = "0.6.0"
 wasmcloud-interface-keyvalue = "0.11"
 wasmbus-rpc = { version = "0.14", features = ["otel"] }
+simple_env_load = "0.2.0"
 
 # test dependencies
 [dev-dependencies]

--- a/kv-vault/Cargo.toml
+++ b/kv-vault/Cargo.toml
@@ -1,8 +1,8 @@
 [package]
 name = "wasmcloud-provider-kv-vault"
 description = "Hashicorp Vault capability provider for the wasmcloud KeyValue capability contract wasmcloud:keyvalue"
-authors = [ "wasmcloud Team" ]
-version = "0.5.0"
+authors = ["wasmcloud Team"]
+version = "0.6.0"
 edition = "2021"
 readme = "README.md"
 repository = "https://github.com/wasmcloud/capability-providers"
@@ -11,7 +11,7 @@ publish = false
 [dependencies]
 async-trait = "0.1"
 atty = "0.2"
-serde = {version = "1.0", features = ["derive"] }
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 thiserror = "1.0"
 tokio = { version = "1", features = ["sync", "rt"] }
@@ -45,4 +45,3 @@ path = "src/lib.rs"
 strip = true
 opt-level = "z"
 lto = true
-

--- a/kv-vault/src/client.rs
+++ b/kv-vault/src/client.rs
@@ -3,19 +3,29 @@
 use std::{string::ToString, sync::Arc};
 
 use serde::{de::DeserializeOwned, Serialize};
+use std::time::Duration;
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tracing::{debug, error, info};
 use vaultrs::api::kv2::responses::SecretVersionMetadata;
-use vaultrs::client::{VaultClient, VaultClientSettings};
+use vaultrs::client::{Client as ClientTrait, VaultClient, VaultClientSettings};
 
 use crate::{config::Config, error::VaultError};
 
 /// Vault HTTP api version. As of Vault 1.9.x (Feb 2022), all http api calls use version 1
 const API_VERSION: u8 = 1;
 
+/// Default TTL for tokens used by this provider. Defaults to 72 hours.
+pub const TOKEN_INCREMENT_TTL: &str = "72h";
+pub const TOKEN_REFRESH_INTERVAL: Duration = Duration::from_secs(60 * 60 * 12); // 12 hours
+
 /// Vault client connection information.
-#[derive(Clone)]
 pub struct Client {
     inner: Arc<vaultrs::client::VaultClient>,
     namespace: String,
+    token_increment_ttl: String,
+    token_refresh_interval: Duration,
+    renew_task: Mutex<Option<JoinHandle<()>>>,
 }
 
 impl Client {
@@ -35,18 +45,30 @@ impl Client {
                 timeout: None,
             })?),
             namespace: config.mount,
+            token_increment_ttl: config
+                .token_increment_ttl
+                .unwrap_or(TOKEN_INCREMENT_TTL.into()),
+            token_refresh_interval: config
+                .token_refresh_interval
+                .unwrap_or(TOKEN_REFRESH_INTERVAL),
+            renew_task: Mutex::new(None),
         })
+    }
+
+    pub fn inner_client(&self) -> Arc<VaultClient> {
+        self.inner.clone()
     }
 
     /// Reads value of secret using namespace and key path
     pub async fn read_secret<D: DeserializeOwned>(&self, path: &str) -> Result<D, VaultError> {
         match vaultrs::kv2::read(self.inner.as_ref(), &self.namespace, path).await {
-            Err(vaultrs::error::ClientError::APIError { code, errors: _ }) if code == 404 => {
-                Err(VaultError::NotFound {
-                    namespace: self.namespace.clone(),
-                    path: path.to_string(),
-                })
-            }
+            Err(vaultrs::error::ClientError::APIError {
+                code: 404,
+                errors: _,
+            }) => Err(VaultError::NotFound {
+                namespace: self.namespace.clone(),
+                path: path.to_string(),
+            }),
             Err(e) => Err(e.into()),
             Ok(val) => Ok(val),
         }
@@ -74,14 +96,66 @@ impl Client {
     /// Lists keys at the path
     pub async fn list_secrets(&self, path: &str) -> Result<Vec<String>, VaultError> {
         match vaultrs::kv2::list(self.inner.as_ref(), &self.namespace, path).await {
-            Err(vaultrs::error::ClientError::APIError { code, errors: _ }) if code == 404 => {
-                Err(VaultError::NotFound {
-                    namespace: self.namespace.clone(),
-                    path: path.to_string(),
-                })
-            }
+            Err(vaultrs::error::ClientError::APIError {
+                code: 404,
+                errors: _,
+            }) => Err(VaultError::NotFound {
+                namespace: self.namespace.clone(),
+                path: path.to_string(),
+            }),
             Err(e) => Err(e.into()),
             Ok(secret_list) => Ok(secret_list),
         }
     }
+
+    /// Sets up a background task to renew the token at the configured interval. This function
+    /// attempts to lock the renew_task mutex and will deadlock if called without first ensuring
+    /// the lock is available.
+    pub async fn set_renewal(&self) {
+        let mut renew_task = self.renew_task.lock().await;
+        if let Some(handle) = renew_task.take() {
+            handle.abort();
+        }
+        let client = self.inner.clone();
+        let interval = self.token_refresh_interval;
+        let ttl = self.token_increment_ttl.clone();
+
+        *renew_task = Some(tokio::spawn(async move {
+            let mut next_interval = tokio::time::interval(interval);
+            loop {
+                next_interval.tick().await;
+                // NOTE(brooksmtownsend): Errors are appropriately logged in the function
+                let _ = renew_self(&client, ttl.as_str()).await;
+            }
+        }));
+    }
+}
+
+impl Drop for Client {
+    fn drop(&mut self) {
+        // NOTE(brooksmtownsend): We're trying to lock here so we don't deadlock on dropping.
+        if let Ok(mut renew_task) = self.renew_task.try_lock() {
+            if let Some(handle) = renew_task.take() {
+                handle.abort();
+            }
+        }
+    }
+}
+
+/// Helper function to renew a client's token, incrementing the validity by `increment`
+async fn renew_self(client: &VaultClient, increment: &str) -> Result<(), VaultError> {
+    debug!("renewing token");
+    client.renew(Some(increment)).await.map_err(|e| {
+        error!("error renewing self token: {}", e);
+        VaultError::from(e)
+    })?;
+
+    let info = client.lookup().await.map_err(|e| {
+        error!("error looking up self token: {}", e);
+        VaultError::from(e)
+    })?;
+
+    let expire_time = info.expire_time.unwrap_or_else(|| "None".to_string());
+    info!(%expire_time, accessor = %info.accessor, "renewed token");
+    Ok(())
 }

--- a/kv-vault/src/config.rs
+++ b/kv-vault/src/config.rs
@@ -41,6 +41,14 @@ impl Default for Config {
 impl Config {
     /// initialize from linkdef values, environment, and defaults
     pub fn from_values(values: &HashMap<String, String>) -> RpcResult<Config> {
+        // load environment variables from file
+        if let Some(env_file) = values.get("env").or_else(|| values.get("ENV")) {
+            eprintln!("file try read env from file: {}", env_file);
+            let data = std::fs::read_to_string(env_file).map_err(|e| {
+                RpcError::ProviderInit(format!("reading env file '{}': {}", env_file, e))
+            })?;
+            simple_env_load::parse_and_set(&data, |k, v| std::env::set_var(k, v));
+        }
         let config = Config {
             addr: env::var("VAULT_ADDR")
                 .ok()


### PR DESCRIPTION
## Feature or Problem
This PR adds an async background task that attempts to renew the vault token on a predefined interval with a predefined ttl (which can be changed with configuration or linkdef parameters.)

Errors while renewing the vault token won't cause anything to error out or panic, it will just error log and retry again after the renewal period.

## Related Issues
N/A

## Release Information
kv-vault 0.6.0

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [x] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
Added integration test that ensures that a previously generated short lived token gets renewed a couple of times.

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
