### PR TITLE
chore: add note about differences between stable and experimental ABIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+> [!IMPORTANT]
+> The providers in this repository are based off interfaces defined in Smithy and are used for RPC between actors over the [stable ABI](https://wasmcloud.com/docs/hosts/abis/wasmbus/). For new providers and component actors, interfaces are defined using [WIT](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md), and codegen is accomplished via the [wasmcloud-provider-wit-bindgen macro](https://github.com/wasmCloud/wasmCloud/tree/main/crates/provider-wit-bindgen). Note that support for WIT is considered **experimental** at this time.
+
 # Capability Providers
 
 This repository contains capability providers for wasmCloud. The providers


### PR DESCRIPTION
## Feature or Problem
This updates the README to distinguish between the stable and experimental ABIs

For a preview of the changes, see https://github.com/connorsmith256/capability-providers/tree/chore/update-readme