### PR TITLE
chore: add better logging around NATS connections

### DIFF
--- a/nats/Cargo.lock
+++ b/nats/Cargo.lock
@@ -3043,7 +3043,7 @@ dependencies = [
 
 [[package]]
 name = "wasmcloud-provider-nats"
-version = "0.17.3"
+version = "0.17.4"
 dependencies = [
  "anyhow",
  "async-nats",

--- a/nats/Cargo.toml
+++ b/nats/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wasmcloud-provider-nats"
-version = "0.17.3"
+version = "0.17.4"
 edition = "2021"
 
 [dependencies]

--- a/nats/tests/nats_test.rs
+++ b/nats/tests/nats_test.rs
@@ -2,11 +2,8 @@ use tokio::sync::oneshot;
 use wasmbus_rpc::provider::prelude::*;
 use wasmcloud_interface_messaging::*;
 use wasmcloud_test_util::{
-    check,
-    cli::print_test_results,
-    provider_test::test_provider,
-    run_selected_spawn,
-    testing::{TestOptions, TestResult},
+    check, cli::print_test_results, provider_test::test_provider, run_selected_spawn,
+    testing::TestOptions,
 };
 
 #[tokio::test]


### PR DESCRIPTION
## Feature or Problem
This PR:
- adds the host ID, actor ID, and link name to the name of each NATS connection. This should increase the ability of operators to debug whether NATS connections related to the provider are still alive
- adds `with_connection_event_logging` to NATS clients, which logs on connection events (which should be rare, including once on initial connection)
- adds an error log if the stream for any subscriber closes unexpectedly

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
v0.17.4

## Consumer Impact
N/A

## Testing
<!---
Declare the testing information for this pull request
--->

<!---
Identify the platforms on which this code was built (include both OS and CPU architecture)
--->
Built on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

<!---
Identify the platforms on which this code was tested (include both OS and CPU architecture)
--->
Tested on platform(s)
- [ ] x86_64-linux
- [ ] aarch64-linux
- [ ] x86_64-darwin
- [ ] aarch64-darwin
- [ ] x86_64-windows

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
Tested manually in a lattice. Deleted and recreated links on the provider to test that NATS connections were dropped from the server:
```
nats server report connections -j | jq '.[] | .name' | rg Messaging | wc -l
```