### PR TITLE
ci(*): pin to 0.26 for par creation

### DIFF
--- a/.github/workflows/TEMPLATE_provider.yml
+++ b/.github/workflows/TEMPLATE_provider.yml
@@ -6,13 +6,13 @@ on:
   push:
     branches: [main]
     paths:
-      - "provider/**"
+      - 'provider/**'
     tags:
-      - "provider-v*"
+      - 'provider-v*'
   pull_request:
     branches: [main]
     paths:
-      - "provider/**"
+      - 'provider/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -42,34 +42,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -118,17 +118,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -148,7 +148,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/blobstore-fs.yml
+++ b/.github/workflows/blobstore-fs.yml
@@ -4,24 +4,24 @@ on:
   push:
     branches: [main]
     paths:
-      - "blobstore-fs/**"
-      - ".github/workflows/blobstore-fs.yml"
+      - 'blobstore-fs/**'
+      - '.github/workflows/blobstore-fs.yml'
     tags:
-      - "blobstore-fs*"
+      - 'blobstore-fs*'
   pull_request:
     branches: [main]
     paths:
-      - "blobstore-fs/**"
-      - ".github/workflows/blobstore-fs.yml"
+      - 'blobstore-fs/**'
+      - '.github/workflows/blobstore-fs.yml'
   workflow_dispatch:
     inputs:
       release:
-        description: "Build github release (enter y)"
-        default: "n"
+        description: 'Build github release (enter y)'
+        default: 'n'
         required: true
       artifact:
-        description: "Build github release and push artifact (enter y)"
-        default: "n"
+        description: 'Build github release and push artifact (enter y)'
+        default: 'n'
         required: true
 
 env:
@@ -76,34 +76,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -152,17 +152,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -182,7 +182,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/blobstore-s3.yml
+++ b/.github/workflows/blobstore-s3.yml
@@ -4,24 +4,24 @@ on:
   push:
     branches: [main]
     paths:
-      - "blobstore-s3/**"
-      - ".github/workflows/blobstore-s3.yml"
+      - 'blobstore-s3/**'
+      - '.github/workflows/blobstore-s3.yml'
     tags:
-      - "blobstore-s3*"
+      - 'blobstore-s3*'
   pull_request:
     branches: [main]
     paths:
-      - "blobstore-s3/**"
-      - ".github/workflows/blobstore-s3.yml"
+      - 'blobstore-s3/**'
+      - '.github/workflows/blobstore-s3.yml'
   workflow_dispatch:
     inputs:
       release:
-        description: "Build github release (enter y)"
-        default: "n"
+        description: 'Build github release (enter y)'
+        default: 'n'
         required: true
       artifact:
-        description: "Build github release and push artifact (enter y)"
-        default: "n"
+        description: 'Build github release and push artifact (enter y)'
+        default: 'n'
         required: true
 
 env:
@@ -76,34 +76,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -152,17 +152,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -182,7 +182,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/httpclient.yml
+++ b/.github/workflows/httpclient.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - "httpclient/**"
+      - 'httpclient/**'
     tags:
-      - "httpclient-v*"
+      - 'httpclient-v*'
   pull_request:
     branches: [main]
     paths:
-      - "httpclient/**"
+      - 'httpclient/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -41,34 +41,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -117,17 +117,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -147,7 +147,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/httpserver.yml
+++ b/.github/workflows/httpserver.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - "httpserver-rs/**"
+      - 'httpserver-rs/**'
     tags:
-      - "httpserver-v*"
+      - 'httpserver-v*'
   pull_request:
     branches: [main]
     paths:
-      - "httpserver-rs/**"
+      - 'httpserver-rs/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -41,34 +41,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -117,17 +117,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -147,7 +147,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/kafka.yml
+++ b/.github/workflows/kafka.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - "messaging-kafka/**"
+      - 'messaging-kafka/**'
     tags:
-      - "messaging-kafka-v*"
+      - 'messaging-kafka-v*'
   pull_request:
     branches: [main]
     paths:
-      - "messaging-kafka/**"
+      - 'messaging-kafka/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -40,34 +40,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -116,17 +116,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -146,7 +146,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/kv-vault.yml
+++ b/.github/workflows/kv-vault.yml
@@ -4,22 +4,22 @@ on:
   push:
     branches: [main]
     paths:
-      - "kv-vault/**"
+      - 'kv-vault/**'
     tags:
-      - "kv-vault-v*"
+      - 'kv-vault-v*'
   pull_request:
     branches: [main]
     paths:
-      - "kv-vault/**"
+      - 'kv-vault/**'
   workflow_dispatch:
     inputs:
       release:
-        description: "Build github release (enter y)"
-        default: "n"
+        description: 'Build github release (enter y)'
+        default: 'n'
         required: true
       artifact:
-        description: "Build github release and push artifact (enter y)"
-        default: "n"
+        description: 'Build github release and push artifact (enter y)'
+        default: 'n'
         required: true
 
 env:
@@ -63,34 +63,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -139,17 +139,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -169,7 +169,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/kvredis.yml
+++ b/.github/workflows/kvredis.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - "kvredis/**"
+      - 'kvredis/**'
     tags:
-      - "kvredis-v*"
+      - 'kvredis-v*'
   pull_request:
     branches: [main]
     paths:
-      - "kvredis/**"
+      - 'kvredis/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -44,34 +44,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -120,17 +120,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -150,7 +150,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/lattice-controller.yml
+++ b/.github/workflows/lattice-controller.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - "lattice-controller/**"
+      - 'lattice-controller/**'
     tags:
-      - "lattice-controller-v*"
+      - 'lattice-controller-v*'
   pull_request:
     branches: [main]
     paths:
-      - "lattice-controller/**"
+      - 'lattice-controller/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -42,34 +42,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -118,17 +118,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -148,7 +148,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:

--- a/.github/workflows/nats.yml
+++ b/.github/workflows/nats.yml
@@ -4,13 +4,13 @@ on:
   push:
     branches: [main]
     paths:
-      - "nats/**"
+      - 'nats/**'
     tags:
-      - "nats-v*"
+      - 'nats-v*'
   pull_request:
     branches: [main]
     paths:
-      - "nats/**"
+      - 'nats/**'
 
 env:
   CARGO_TERM_COLOR: always
@@ -41,34 +41,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -117,17 +117,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -147,7 +147,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:
@@ -217,7 +220,7 @@ jobs:
 
       - name: Push provider archive to AzureCR
         env:
-          oci-repository: "nats_messaging"
+          oci-repository: 'nats_messaging'
         uses: wasmcloud/common-actions/oci-artifact-release@main
         with:
           artifact-path: ${{ env.working-directory }}/build/${{ env.oci-repository }}.par.gz

--- a/.github/workflows/sqldb-postgres.yml
+++ b/.github/workflows/sqldb-postgres.yml
@@ -4,22 +4,22 @@ on:
   push:
     branches: [main]
     paths:
-      - "sqldb-postgres/**"
+      - 'sqldb-postgres/**'
     tags:
-      - "sqldb-postgres-v*"
+      - 'sqldb-postgres-v*'
   pull_request:
     branches: [main]
     paths:
-      - "sqldb-postgres/**"
+      - 'sqldb-postgres/**'
   workflow_dispatch:
     inputs:
       release:
-        description: "Build github release (enter y)"
-        default: "n"
+        description: 'Build github release (enter y)'
+        default: 'n'
         required: true
       artifact:
-        description: "Build github release and push artifact (enter y)"
-        default: "n"
+        description: 'Build github release and push artifact (enter y)'
+        default: 'n'
         required: true
 
 env:
@@ -63,34 +63,34 @@ jobs:
           # old versions. But if we build on the old version, it is compatible with the newer
           # versions running in ubuntu 22 and its ilk
           - {
-              os: "ubuntu-20.04",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'ubuntu-20.04',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "ubuntu-20.04",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-unknown-linux-gnu/release/",
+              os: 'ubuntu-20.04',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-unknown-linux-gnu/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "amd64",
-              extension: "",
-              targetPath: "target/release/",
+              os: 'macos-latest',
+              arch: 'amd64',
+              extension: '',
+              targetPath: 'target/release/',
             }
           - {
-              os: "windows-latest",
-              arch: "amd64",
-              extension: ".exe",
-              targetPath: "target/release/",
+              os: 'windows-latest',
+              arch: 'amd64',
+              extension: '.exe',
+              targetPath: 'target/release/',
             }
           - {
-              os: "macos-latest",
-              arch: "aarch64",
-              extension: "",
-              targetPath: "target/aarch64-apple-darwin/release/",
+              os: 'macos-latest',
+              arch: 'aarch64',
+              extension: '',
+              targetPath: 'target/aarch64-apple-darwin/release/',
             }
     runs-on: ${{ matrix.config.os }}
     steps:
@@ -139,17 +139,17 @@ jobs:
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch != 'aarch64'
-        run: "cargo build --release"
+        run: 'cargo build --release'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'macos-latest'
-        run: "cargo build --release --target aarch64-apple-darwin"
+        run: 'cargo build --release --target aarch64-apple-darwin'
 
       - name: build release
         working-directory: ${{ env.working-directory }}
         if: matrix.config.arch == 'aarch64' && matrix.config.os == 'ubuntu-20.04'
-        run: "cargo build --release --target aarch64-unknown-linux-gnu"
+        run: 'cargo build --release --target aarch64-unknown-linux-gnu'
 
       - name: Determine artifact name
         shell: bash
@@ -169,7 +169,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v4
-      - uses: wasmcloud/common-actions/install-wash@main
+      - name: Install wash 0.26
+        run: |
+          curl -s https://packagecloud.io/install/repositories/wasmCloud/core/script.deb.sh | bash
+          apt install wash=0.26.0
       # Downloads all artifacts
       - uses: actions/download-artifact@v3
         with:


### PR DESCRIPTION
Signed-off-by: Brooks Townsend <brooksmtownsend@gmail.com>

## Feature or Problem
This PR pins to wash 0.26 for provider archive generation as these providers are only used with pre-1.0 wasmCloud and need the capability contract ID.

## Related Issues
<!--- 
Link to any issues or correlated pull requests that are related to this PR. For example, if this PR fixes an issue, link to that issue here.
--->

## Release Information
<!---
Clearly state the target release for this code. If there isn't a specific target version, you can state the `next` release, etc. 
--->

## Consumer Impact
<!---
Indicate the impact, if any, this change will have on other consumers, dependencies, or dependents. In other words, the "blast radius" of the impact of this change and what steps related projects may need to take in response to this.
--->

## Testing
<!---
Declare the testing information for this pull request
--->

### Unit Test(s)
<!---
Indicate if unit tests were added or modified, and if so, which ones 
--->

### Acceptance or Integration
<!---
Indicate any changes or additions to the acceptance or integration test suite 
--->

### Manual Verification
<!---
Mandatory. Indicate the steps that you took to verify that this pull request works 
--->
